### PR TITLE
Fix card list not refreshing after edit

### DIFF
--- a/Sahara/Feature/Gallery/CardList/CardListViewController.swift
+++ b/Sahara/Feature/Gallery/CardList/CardListViewController.swift
@@ -204,6 +204,9 @@ final class CardListViewController: UIViewController {
                 var snapshot = NSDiffableDataSourceSnapshot<Int, ObjectId>()
                 snapshot.appendSections([0])
                 snapshot.appendItems(cardIds)
+                let existing = Set(dataSource.snapshot().itemIdentifiers)
+                let toReconfigure = cardIds.filter { existing.contains($0) }
+                snapshot.reconfigureItems(toReconfigure)
                 dataSource.apply(snapshot, animatingDifferences: true) {
                     owner.pinterestLayout.invalidateLayout()
                 }


### PR DESCRIPTION
Closes #29

## 변경 내용

**수정**
- CalendarDetail 목록에서 카드 수정 후 돌아왔을 때 변경사항이 즉시 반영되도록 수정

## 결정 근거

- **reconfigureItems** — DiffableDataSource가 ObjectId(identity)만 비교하므로 content 변경을 감지하지 못함. `reconfigureItems()`로 기존 셀의 cell provider를 다시 호출하여 최신 데이터 반영. `reloadItems()`는 셀 전체 재생성으로 이미지 깜빡임 발생