### PR TITLE
Pass camera originalData to ImageSourceData

### DIFF
--- a/Sahara/Feature/CardInfo/Component/Camera/CameraViewController.swift
+++ b/Sahara/Feature/CardInfo/Component/Camera/CameraViewController.swift
@@ -162,6 +162,7 @@ extension CameraViewController: AVCapturePhotoCaptureDelegate {
         let format = ImageFormatHelper.detect(from: imageData)
         let imageSource = ImageSourceData(
             image: image,
+            originalData: imageData,
             format: format
         )
 


### PR DESCRIPTION
Closes #34

## 변경 내용

**수정**
- 카메라 촬영 시 원본 바이트 데이터를 ImageSourceData에 전달하도록 수정

## 결정 근거

- **fileDataRepresentation() 활용** — 이미 카메라 delegate에서 받고 있는 원본 바이트를 버리지 않고 그대로 전달. 편집 없이 저장 시 re-encoding bypass 가능