### PR TITLE
Migrate Realm DB file from Documents/ to Application Support/

### DIFF
--- a/Sahara/AppDelegate.swift
+++ b/Sahara/AppDelegate.swift
@@ -45,6 +45,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     private func configureRealm() {
+        RealmManager.migrateRealmFileIfNeeded()
         let config = RealmManager.createConfiguration()
         Realm.Configuration.defaultConfiguration = config
     }

--- a/Sahara/Common/Manager/RealmManager.swift
+++ b/Sahara/Common/Manager/RealmManager.swift
@@ -10,6 +10,8 @@ import OSLog
 import RealmSwift
 import RxSwift
 
+private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "Sahara", category: "RealmMigration")
+
 enum DatePeriod {
     case day(Date)
     case month(Date)
@@ -50,8 +52,68 @@ final class RealmManager: RealmManagerProtocol {
         self.configuration = configuration
     }
 
+    static var realmFileURL: URL {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        return appSupport.appendingPathComponent("default.realm")
+    }
+
+    static func migrateRealmFileIfNeeded(
+        documentsDir: URL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0],
+        appSupportDir: URL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+    ) {
+        let fm = FileManager.default
+        let oldURL = documentsDir.appendingPathComponent("default.realm")
+        let newURL = appSupportDir.appendingPathComponent("default.realm")
+
+        guard fm.fileExists(atPath: oldURL.path) else { return }
+
+        try? fm.createDirectory(at: appSupportDir, withIntermediateDirectories: true)
+
+        if fm.fileExists(atPath: newURL.path) {
+            try? fm.removeItem(at: oldURL)
+            cleanupAuxiliaryFiles(at: documentsDir)
+            logger.notice("Realm file already at new location — removed old file from Documents/")
+            return
+        }
+
+        do {
+            try fm.moveItem(at: oldURL, to: newURL)
+            cleanupAuxiliaryFiles(at: documentsDir)
+            logger.notice("Realm file migrated from Documents/ to Application Support/")
+        } catch {
+            logger.error("Realm file migration failed: \(error.localizedDescription)")
+        }
+    }
+
+    static func resolveRealmFileURL(
+        documentsDir: URL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0],
+        appSupportDir: URL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+    ) -> URL {
+        let fm = FileManager.default
+        let appSupportURL = appSupportDir.appendingPathComponent("default.realm")
+        let documentsURL = documentsDir.appendingPathComponent("default.realm")
+
+        if fm.fileExists(atPath: appSupportURL.path) {
+            return appSupportURL
+        }
+        if fm.fileExists(atPath: documentsURL.path) {
+            return documentsURL
+        }
+        return appSupportURL
+    }
+
+    private static func cleanupAuxiliaryFiles(at directory: URL) {
+        let fm = FileManager.default
+        let auxiliaryExtensions = ["lock", "note", "management"]
+        for ext in auxiliaryExtensions {
+            let url = directory.appendingPathComponent("default.\(ext)")
+            try? fm.removeItem(at: url)
+        }
+    }
+
     static func createConfiguration(schemaVersion: UInt64 = currentSchemaVersion, migrationBlock: MigrationBlock? = nil) -> Realm.Configuration {
         var config = Realm.Configuration()
+        config.fileURL = resolveRealmFileURL()
         config.schemaVersion = schemaVersion
         config.migrationBlock = migrationBlock ?? defaultMigrationBlock
         return config

--- a/SaharaTests/RealmMigrationTests.swift
+++ b/SaharaTests/RealmMigrationTests.swift
@@ -107,4 +107,96 @@ final class RealmMigrationTests: XCTestCase {
         XCTAssertEqual(config.schemaVersion, 1)
         XCTAssertNotNil(config.migrationBlock)
     }
+
+    // MARK: - Realm File Migration Tests
+
+    private func makeTempDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("realm-migration-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    func test_migrateRealmFile_movesFromDocumentsToAppSupport() throws {
+        let fm = FileManager.default
+        let fakeDocuments = try makeTempDir()
+        let fakeAppSupport = try makeTempDir()
+
+        defer {
+            try? fm.removeItem(at: fakeDocuments)
+            try? fm.removeItem(at: fakeAppSupport)
+        }
+
+        let oldRealmURL = fakeDocuments.appendingPathComponent("default.realm")
+        let oldLockURL = fakeDocuments.appendingPathComponent("default.lock")
+        let oldManagementURL = fakeDocuments.appendingPathComponent("default.management")
+        let testData = Data("test-realm-data".utf8)
+
+        try testData.write(to: oldRealmURL)
+        try Data().write(to: oldLockURL)
+        try Data().write(to: oldManagementURL)
+
+        RealmManager.migrateRealmFileIfNeeded(
+            documentsDir: fakeDocuments,
+            appSupportDir: fakeAppSupport
+        )
+
+        let newRealmURL = fakeAppSupport.appendingPathComponent("default.realm")
+        XCTAssertTrue(fm.fileExists(atPath: newRealmURL.path), "Realm file should exist at new location")
+        XCTAssertFalse(fm.fileExists(atPath: oldRealmURL.path), "Realm file should not exist at old location")
+        XCTAssertFalse(fm.fileExists(atPath: oldLockURL.path), "Lock file should be cleaned up")
+        XCTAssertFalse(fm.fileExists(atPath: oldManagementURL.path), "Management file should be cleaned up")
+
+        let migratedData = try Data(contentsOf: newRealmURL)
+        XCTAssertEqual(migratedData, testData, "Migrated file content should match original")
+    }
+
+    func test_migrateRealmFile_noFileInDocuments_doesNothing() throws {
+        let fm = FileManager.default
+        let fakeDocuments = try makeTempDir()
+        let fakeAppSupport = try makeTempDir()
+
+        defer {
+            try? fm.removeItem(at: fakeDocuments)
+            try? fm.removeItem(at: fakeAppSupport)
+        }
+
+        RealmManager.migrateRealmFileIfNeeded(
+            documentsDir: fakeDocuments,
+            appSupportDir: fakeAppSupport
+        )
+
+        let newRealmURL = fakeAppSupport.appendingPathComponent("default.realm")
+        XCTAssertFalse(fm.fileExists(atPath: newRealmURL.path), "No file should be created when source doesn't exist")
+    }
+
+    func test_migrateRealmFile_fileAlreadyAtNewLocation_removesOldFile() throws {
+        let fm = FileManager.default
+        let fakeDocuments = try makeTempDir()
+        let fakeAppSupport = try makeTempDir()
+
+        defer {
+            try? fm.removeItem(at: fakeDocuments)
+            try? fm.removeItem(at: fakeAppSupport)
+        }
+
+        let oldRealmURL = fakeDocuments.appendingPathComponent("default.realm")
+        let newRealmURL = fakeAppSupport.appendingPathComponent("default.realm")
+        let oldData = Data("old-data".utf8)
+        let newData = Data("new-data".utf8)
+
+        try oldData.write(to: oldRealmURL)
+        try newData.write(to: newRealmURL)
+
+        RealmManager.migrateRealmFileIfNeeded(
+            documentsDir: fakeDocuments,
+            appSupportDir: fakeAppSupport
+        )
+
+        XCTAssertFalse(fm.fileExists(atPath: oldRealmURL.path), "Old file should be removed")
+        XCTAssertTrue(fm.fileExists(atPath: newRealmURL.path), "New file should be preserved")
+
+        let preservedData = try Data(contentsOf: newRealmURL)
+        XCTAssertEqual(preservedData, newData, "New location file should keep its original content")
+    }
 }


### PR DESCRIPTION
Closes #32

## 변경 내용

**추가**
- Realm DB 파일을 Documents/에서 Application Support/로 이전하는 마이그레이션 로직
- 앱 시작 시 자동으로 파일 위치를 감지하고, 이전이 필요하면 이동 수행
- 마이그레이션 실패 시 기존 위치(Documents/)에서 계속 작동하는 폴백 처리
- 파일 이동 테스트 3개 (정상 이동, 신규 설치, 중복 파일)

**수정**
- Realm Configuration에 명시적 fileURL 설정 (Application Support/ 기반)

## 결정 근거

- **DI 파라미터** — 마이그레이션 함수에 디렉토리 경로를 주입 가능하게 설계하여 테스트에서 임시 디렉토리로 격리
- **Graceful degradation** — 이동 실패 시 크래시 없이 Documents/에서 계속 동작, 스키마 버전 변경 불필요 (파일 이동이지 스키마 변경 아님)

## Test Plan
- [x] 기존 데이터가 있는 시뮬레이터에서 업데이트 후 데이터 유지 확인
- [x] 신규 설치 시 Application Support/에 Realm 파일 생성 확인
- [x] `make test` 전체 통과 확인