### PR TITLE
Make Card.editedImageData optional

### DIFF
--- a/Sahara/Common/Manager/RealmManager.swift
+++ b/Sahara/Common/Manager/RealmManager.swift
@@ -136,7 +136,9 @@ final class RealmManager: RealmManagerProtocol {
         }
 
         if oldSchemaVersion < 3 {
+            // v1.6.1 → v2.0.0 스키마 변경 대응
             // Card: imagePath(String?) 추가 → Realm이 자동으로 nil 할당
+            // Card: editedImageData(Data → Data?) 변경 → Realm이 자동으로 optional 전환
         }
     }
 
@@ -453,21 +455,18 @@ final class RealmManager: RealmManagerProtocol {
     func fetchImageData(for cardId: ObjectId) -> Data? {
         guard let realm = try? getRealm() else { return nil }
         guard let card = realm.object(ofType: Card.self, forPrimaryKey: cardId) else { return nil }
+        guard let resolvedData = card.resolvedImageData() else { return nil }
 
-        if let imagePath = card.imagePath,
-           let diskData = ImageFileManager.shared.loadImageFile(at: imagePath) {
-            Logger.database.info("[ImageStorage] Loaded from disk: \(imagePath)")
-            return diskData
+        if card.imagePath != nil {
+            Logger.database.info("[ImageStorage] Loaded from disk: \(card.imagePath!)")
+            return resolvedData
         }
 
-        let realmData = card.editedImageData
-        guard !realmData.isEmpty else { return nil }
-
-        Logger.database.notice("[ImageStorage] Loaded from Realm (\(realmData.count / 1024)KB), starting lazy migration...")
+        Logger.database.notice("[ImageStorage] Loaded from Realm (\(resolvedData.count / 1024)KB), starting lazy migration...")
 
         // Lazy migration: 기존 Realm 데이터를 백그라운드에서 디스크로 이전
         let format = card.imageFormat ?? "jpeg"
-        let dataCopy = Data(realmData)
+        let dataCopy = Data(resolvedData)
         DispatchQueue.global(qos: .utility).async { [weak self] in
             guard let self = self else { return }
             do {
@@ -475,7 +474,7 @@ final class RealmManager: RealmManagerProtocol {
                 _ = self.update { realm in
                     guard let card = realm.object(ofType: Card.self, forPrimaryKey: cardId) else { return }
                     card.imagePath = fileName
-                    card.editedImageData = Data()
+                    card.editedImageData = nil
                 }
                 Logger.database.notice("[ImageStorage] Lazy migration done: \(fileName)")
             } catch {
@@ -483,7 +482,7 @@ final class RealmManager: RealmManagerProtocol {
             }
         }
 
-        return realmData
+        return resolvedData
     }
 
     func deleteCard(forPrimaryKey key: ObjectId) -> Observable<Void> {
@@ -604,11 +603,7 @@ final class MockRealmManager: RealmManagerProtocol {
         guard let card = objects.first(where: { ($0 as? Card)?.id == cardId }) as? Card else {
             return nil
         }
-        if let imagePath = card.imagePath,
-           let diskData = ImageFileManager.shared.loadImageFile(at: imagePath) {
-            return diskData
-        }
-        return card.editedImageData.isEmpty ? nil : card.editedImageData
+        return card.resolvedImageData()
     }
 
     func deleteCard(forPrimaryKey key: ObjectId) -> Observable<Void> {

--- a/Sahara/Common/Model/Card.swift
+++ b/Sahara/Common/Model/Card.swift
@@ -43,7 +43,7 @@ final class Card: Object {
     @Persisted var createdDate: Date
     @Persisted var modifiedDate: Date?
     
-    @Persisted var editedImageData: Data
+    @Persisted var editedImageData: Data?
     @Persisted var imagePath: String?
     @Persisted var imageFormat: String?
     @Persisted var drawingData: Data?
@@ -64,7 +64,7 @@ final class Card: Object {
     convenience init(
         date: Date,
         createdDate: Date,
-        editedImageData: Data,
+        editedImageData: Data? = nil,
         memo: String? = nil,
         latitude: Double? = nil,
         longitude: Double? = nil,
@@ -84,12 +84,13 @@ final class Card: Object {
 // MARK: - Image Loading
 
 extension Card {
-    func resolvedImageData() -> Data {
+    func resolvedImageData() -> Data? {
         if let imagePath = imagePath,
            let diskData = ImageFileManager.shared.loadImageFile(at: imagePath) {
             return diskData
         }
-        return editedImageData
+        guard let data = editedImageData, !data.isEmpty else { return nil }
+        return data
     }
 }
 

--- a/Sahara/Common/Model/CardDTOs.swift
+++ b/Sahara/Common/Model/CardDTOs.swift
@@ -27,7 +27,7 @@ struct CardListItemDTO {
 struct CardDetailDTO {
     let id: ObjectId
     let date: Date
-    let editedImageData: Data
+    let editedImageData: Data?
     let memo: String?
     let latitude: Double?
     let longitude: Double?
@@ -54,7 +54,7 @@ struct SearchCardDTO {
     init(from card: Card) {
         self.id = card.id
         self.isLocked = card.isLocked
-        self.imageSize = ImageDownsampler.imageSize(from: card.resolvedImageData()) ?? CGSize(width: 1, height: 1)
+        self.imageSize = card.resolvedImageData().flatMap(ImageDownsampler.imageSize) ?? CGSize(width: 1, height: 1)
     }
 }
 

--- a/Sahara/Feature/CardDetail/PhotoCardViewModel.swift
+++ b/Sahara/Feature/CardDetail/PhotoCardViewModel.swift
@@ -45,10 +45,11 @@ final class PhotoCardViewModel: BaseViewModelProtocol {
             .withUnretained(self)
             .observe(on: MainScheduler.instance)
             .bind { owner, _ in
-                guard let card = owner.realmManager.fetchObject(Card.self, forPrimaryKey: owner.cardId) else { return }
+                guard let card = owner.realmManager.fetchObject(Card.self, forPrimaryKey: owner.cardId),
+                      let imageData = card.resolvedImageData() else { return }
 
                 let data = (
-                    image: card.resolvedImageData(),
+                    image: imageData,
                     date: card.date,
                     latitude: card.latitude,
                     longitude: card.longitude,

--- a/Sahara/Feature/CardInfo/CardInfoViewModel.swift
+++ b/Sahara/Feature/CardInfo/CardInfoViewModel.swift
@@ -104,8 +104,7 @@ final class CardInfoViewModel: BaseViewModelProtocol {
 
     private func createImageSourceData(from card: Card, editedImage: UIImage, imageData: Data) -> ImageSourceData {
         let format = card.imageFormat.flatMap { ImageSourceData.ImageFormat(rawValue: $0) }
-        let originalData: Data? = imageData.isEmpty ? nil : imageData
-        return ImageSourceData(image: editedImage, originalData: originalData, format: format)
+        return ImageSourceData(image: editedImage, originalData: imageData, format: format)
     }
 
     init(cardToEdit cardId: ObjectId, sourceType: EditSourceType, realmManager: RealmManagerProtocol = RealmManager.shared, ocrManager: OCRManagerProtocol = OCRManager.shared, imagePrepareService: ImagePrepareServiceProtocol = ImagePrepareService()) {
@@ -119,7 +118,7 @@ final class CardInfoViewModel: BaseViewModelProtocol {
             return
         }
 
-        let imageData = card.resolvedImageData()
+        guard let imageData = card.resolvedImageData() else { return }
         loadCardData(from: card, imageData: imageData)
 
         if let editedImage = self.editedImage {
@@ -335,7 +334,7 @@ final class CardInfoViewModel: BaseViewModelProtocol {
         let card = Card(
             date: date,
             createdDate: Date(),
-            editedImageData: Data(),
+            editedImageData: nil,
             memo: memo,
             latitude: location?.coordinate.latitude,
             longitude: location?.coordinate.longitude,
@@ -486,7 +485,7 @@ final class CardInfoViewModel: BaseViewModelProtocol {
             card.date = date
             if let newImagePath = newImagePath {
                 card.imagePath = newImagePath
-                card.editedImageData = Data()
+                card.editedImageData = nil
             } else {
                 card.editedImageData = imageData.editedImageData
             }

--- a/Sahara/Feature/Gallery/Tab/Theme/ThemeViewModel.swift
+++ b/Sahara/Feature/Gallery/Tab/Theme/ThemeViewModel.swift
@@ -70,7 +70,10 @@ final class ThemeViewModel: BaseViewModelProtocol {
 
         return realmManager.observeAllCards()
             .map { cards in
-                cards.map { (id: $0.id, imageData: $0.resolvedImageData()) }
+                cards.compactMap { card -> (id: ObjectId, imageData: Data)? in
+                    guard let data = card.resolvedImageData() else { return nil }
+                    return (id: card.id, imageData: data)
+                }
             }
             .observe(on: backgroundScheduler)
             .map { [weak self] items -> [ThemeGroup] in

--- a/SaharaTests/Mocks/MockRealmManager.swift
+++ b/SaharaTests/Mocks/MockRealmManager.swift
@@ -122,11 +122,7 @@ final class MockRealmManager: RealmManagerProtocol {
 
     func fetchImageData(for cardId: ObjectId) -> Data? {
         guard let card = mockCards.first(where: { $0.id == cardId }) else { return nil }
-        if let imagePath = card.imagePath,
-           let diskData = ImageFileManager.shared.loadImageFile(at: imagePath) {
-            return diskData
-        }
-        return card.editedImageData.isEmpty ? nil : card.editedImageData
+        return card.resolvedImageData()
     }
 
     func deleteCard(forPrimaryKey key: ObjectId) -> Observable<Void> {


### PR DESCRIPTION
Closes #40

## 변경 내용

**수정**
- `editedImageData` 저장 타입을 non-optional에서 optional로 변경
- 이미지가 없는 상태를 빈 `Data()` 대신 `nil`로 표현
- 이미지 로딩 로직을 `resolvedImageData()` 단일 메서드로 통일 (RealmManager, MockRealmManager 모두)
- Realm 마이그레이션 v3에 버전 정보 및 optional 전환 주석 추가

## 결정 근거

- **nil vs Data()** — 빈 Data는 "데이터가 있지만 비어있음"과 "데이터가 없음"을 구분할 수 없음. Optional이 의미적으로 정확하고 guard let 패턴으로 안전하게 처리 가능