### PR TITLE
Add backup and restore with custom .sahara file format

### DIFF
--- a/Sahara.xcodeproj/project.pbxproj
+++ b/Sahara.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		03E2B5DA2E866F3C00A8C8DA /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 03E2B5D92E866F3C00A8C8DA /* RxCocoa */; };
 		03E2B5DC2E866F3C00A8C8DA /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 03E2B5DB2E866F3C00A8C8DA /* RxSwift */; };
 		03E2B5DF2E866F4B00A8C8DA /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 03E2B5DE2E866F4B00A8C8DA /* Kingfisher */; };
+		03F1A0032EC3D00100B4C003 /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 03F1A0022EC3D00100B4C002 /* ZIPFoundation */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -113,6 +114,7 @@
 				035A09162E90D2B900221B3E /* FirebaseCrashlytics in Frameworks */,
 				039745922E86DFD100BDA511 /* Alamofire in Frameworks */,
 				03E2B5DF2E866F4B00A8C8DA /* Kingfisher in Frameworks */,
+				03F1A0032EC3D00100B4C003 /* ZIPFoundation in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -203,6 +205,7 @@
 				035A09132E90D2B900221B3E /* FirebaseAnalytics */,
 				035A09152E90D2B900221B3E /* FirebaseCrashlytics */,
 				0373CD562EA157EA001DD9A0 /* FirebaseMessaging */,
+				03F1A0022EC3D00100B4C002 /* ZIPFoundation */,
 			);
 			productName = Sahara;
 			productReference = 03E2B5B52E8664AB00A8C8DA /* Sahara.app */;
@@ -247,6 +250,7 @@
 				039745932E86E08500BDA511 /* XCRemoteSwiftPackageReference "realm-swift" */,
 				030F3A3E2E8B6E02000E04B5 /* XCRemoteSwiftPackageReference "RxDataSources" */,
 				035A09122E90D2B900221B3E /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+				03F1A0012EC3D00100B4C001 /* XCRemoteSwiftPackageReference "ZIPFoundation" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 03E2B5B62E8664AB00A8C8DA /* Products */;
@@ -674,6 +678,14 @@
 				minimumVersion = 8.5.0;
 			};
 		};
+		03F1A0012EC3D00100B4C001 /* XCRemoteSwiftPackageReference "ZIPFoundation" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/weichsel/ZIPFoundation.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.9.19;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -731,6 +743,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 03E2B5DD2E866F4B00A8C8DA /* XCRemoteSwiftPackageReference "Kingfisher" */;
 			productName = Kingfisher;
+		};
+		03F1A0022EC3D00100B4C002 /* ZIPFoundation */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 03F1A0012EC3D00100B4C001 /* XCRemoteSwiftPackageReference "ZIPFoundation" */;
+			productName = ZIPFoundation;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Sahara.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Sahara.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0cd5d5c6d7d74b954d7511774f99caf8df83a7805413170cda45aa84efd110f3",
+  "originHash" : "1d780b5e7d4b48d976fb698752aa1c45cbe3d996ad151dd43ae2c2bbb52140ed",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -188,6 +188,15 @@
       "state" : {
         "revision" : "2547102afd04fe49f1b286090f13ebce07284980",
         "version" : "1.31.1"
+      }
+    },
+    {
+      "identity" : "zipfoundation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/weichsel/ZIPFoundation.git",
+      "state" : {
+        "revision" : "22787ffb59de99e5dc1fbfe80b19c97a904ad48d",
+        "version" : "0.9.20"
       }
     }
   ],

--- a/Sahara/Common/Manager/BackupManager.swift
+++ b/Sahara/Common/Manager/BackupManager.swift
@@ -1,0 +1,307 @@
+//
+//  BackupManager.swift
+//  Sahara
+//
+//  Created by 금가경 on 3/8/26.
+//
+
+import Foundation
+import OSLog
+import RealmSwift
+import ZIPFoundation
+
+private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "Sahara", category: "Backup")
+
+enum BackupError: LocalizedError {
+    case invalidBackupFile
+    case missingMetadata
+    case missingRealmFile
+    case incompatibleSchemaVersion(backup: UInt64, current: UInt64)
+    case exportFailed(Error)
+    case importFailed(Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidBackupFile:
+            return NSLocalizedString("backup.invalid_file", comment: "")
+        case .missingMetadata:
+            return NSLocalizedString("backup.invalid_file", comment: "")
+        case .missingRealmFile:
+            return NSLocalizedString("backup.invalid_file", comment: "")
+        case .incompatibleSchemaVersion:
+            return NSLocalizedString("backup.version_mismatch", comment: "")
+        case .exportFailed(let error):
+            return "\(NSLocalizedString("backup.export_failed", comment: "")): \(error.localizedDescription)"
+        case .importFailed(let error):
+            return "\(NSLocalizedString("backup.import_failed", comment: "")): \(error.localizedDescription)"
+        }
+    }
+}
+
+protocol BackupManagerProtocol {
+    func exportPhotosOnly(progress: @escaping (Double) -> Void) throws -> URL
+    func exportBackup(progress: @escaping (Double) -> Void) throws -> URL
+    func validateBackup(at url: URL) throws -> BackupMetadata
+    func importBackup(from url: URL, progress: @escaping (Double) -> Void) throws
+}
+
+final class BackupManager: BackupManagerProtocol {
+    static let shared = BackupManager()
+
+    static let backupFileExtension = "sahara"
+
+    private let fileManager = FileManager.default
+    private let realmManager: RealmManagerProtocol
+    private let imageFileManager: ImageFileManager
+
+    init(
+        realmManager: RealmManagerProtocol = RealmManager.shared,
+        imageFileManager: ImageFileManager = .shared
+    ) {
+        self.realmManager = realmManager
+        self.imageFileManager = imageFileManager
+    }
+
+    private var cardImagesDirectory: URL {
+        let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        return appSupport.appendingPathComponent("CardImages", isDirectory: true)
+    }
+
+    // MARK: - Export Photos Only
+
+    func exportPhotosOnly(progress: @escaping (Double) -> Void) throws -> URL {
+        try migrateAllLegacyImages()
+        progress(0.2)
+
+        let tempDir = fileManager.temporaryDirectory.appendingPathComponent("sahara-photos-\(UUID().uuidString)")
+        try fileManager.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: tempDir) }
+
+        let archiveURL = fileManager.temporaryDirectory.appendingPathComponent("Sahara_Photos_\(Self.fileDateFormatter.string(from: Date())).zip")
+        try? fileManager.removeItem(at: archiveURL)
+
+        let archive = try Archive(url: archiveURL, accessMode: .create)
+
+        let imageFiles = try imageFilesInDirectory()
+        let totalFiles = Double(max(imageFiles.count, 1))
+
+        for (index, fileURL) in imageFiles.enumerated() {
+            try archive.addEntry(
+                with: "CardImages/\(fileURL.lastPathComponent)",
+                fileURL: fileURL
+            )
+            progress(0.2 + 0.8 * Double(index + 1) / totalFiles)
+        }
+
+        logger.notice("Photos exported: \(imageFiles.count) files")
+        return archiveURL
+    }
+
+    // MARK: - Export Backup
+
+    func exportBackup(progress: @escaping (Double) -> Void) throws -> URL {
+        try migrateAllLegacyImages()
+        progress(0.1)
+
+        let tempDir = fileManager.temporaryDirectory.appendingPathComponent("sahara-backup-\(UUID().uuidString)")
+        try fileManager.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: tempDir) }
+
+        let realmCopyURL = tempDir.appendingPathComponent("default.realm")
+        let realm = try Realm(configuration: realmManager.createConfiguration())
+        try realm.writeCopy(toFile: realmCopyURL)
+        progress(0.3)
+
+        let cardCount = realm.objects(Card.self).count
+
+        let metadata = BackupMetadata.create(cardCount: cardCount)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = .prettyPrinted
+        let metadataData = try encoder.encode(metadata)
+        let metadataURL = tempDir.appendingPathComponent("metadata.json")
+        try metadataData.write(to: metadataURL)
+        progress(0.4)
+
+        let archiveURL = fileManager.temporaryDirectory.appendingPathComponent("Sahara_\(Self.fileDateFormatter.string(from: Date())).\(Self.backupFileExtension)")
+        try? fileManager.removeItem(at: archiveURL)
+
+        let archive = try Archive(url: archiveURL, accessMode: .create)
+
+        try archive.addEntry(with: "metadata.json", fileURL: metadataURL)
+        try archive.addEntry(with: "default.realm", fileURL: realmCopyURL)
+
+        let imageFiles = try imageFilesInDirectory()
+        let totalSteps = Double(max(imageFiles.count, 1))
+        for (index, imageFile) in imageFiles.enumerated() {
+            try archive.addEntry(
+                with: "CardImages/\(imageFile.lastPathComponent)",
+                fileURL: imageFile
+            )
+            progress(0.4 + 0.6 * Double(index + 1) / totalSteps)
+        }
+
+        progress(1.0)
+        logger.notice("Backup exported: \(cardCount) cards")
+        return archiveURL
+    }
+
+    // MARK: - Validate
+
+    func validateBackup(at url: URL) throws -> BackupMetadata {
+        let archive: Archive
+        do {
+            archive = try Archive(url: url, accessMode: .read)
+        } catch {
+            throw BackupError.invalidBackupFile
+        }
+
+        guard let metadataEntry = archive["metadata.json"] else {
+            throw BackupError.missingMetadata
+        }
+
+        var metadataData = Data()
+        _ = try archive.extract(metadataEntry) { data in
+            metadataData.append(data)
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let metadata = try decoder.decode(BackupMetadata.self, from: metadataData)
+
+        if metadata.schemaVersion > RealmManager.currentSchemaVersion {
+            throw BackupError.incompatibleSchemaVersion(
+                backup: metadata.schemaVersion,
+                current: RealmManager.currentSchemaVersion
+            )
+        }
+
+        guard archive["default.realm"] != nil else {
+            throw BackupError.missingRealmFile
+        }
+
+        return metadata
+    }
+
+    // MARK: - Import
+
+    func importBackup(from url: URL, progress: @escaping (Double) -> Void) throws {
+        progress(0.1)
+
+        let tempDir = fileManager.temporaryDirectory.appendingPathComponent("sahara-import-\(UUID().uuidString)")
+        try fileManager.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: tempDir) }
+
+        try fileManager.unzipItem(at: url, to: tempDir)
+        progress(0.3)
+
+        let extractedRealmURL = tempDir.appendingPathComponent("default.realm")
+        let extractedImagesDir = tempDir.appendingPathComponent("CardImages")
+
+        guard fileManager.fileExists(atPath: extractedRealmURL.path) else {
+            throw BackupError.missingRealmFile
+        }
+
+        var backupConfig = realmManager.createConfiguration()
+        backupConfig.fileURL = extractedRealmURL
+        backupConfig.readOnly = true
+
+        let backupRealm = try Realm(configuration: backupConfig)
+        let backupCards = backupRealm.objects(Card.self)
+        progress(0.4)
+
+        let currentImagesURL = cardImagesDirectory
+        let imagesBackupURL = currentImagesURL.appendingPathExtension("bak")
+
+        try? fileManager.removeItem(at: imagesBackupURL)
+        if fileManager.fileExists(atPath: currentImagesURL.path) {
+            try fileManager.moveItem(at: currentImagesURL, to: imagesBackupURL)
+        }
+
+        do {
+            if fileManager.fileExists(atPath: extractedImagesDir.path) {
+                try fileManager.moveItem(at: extractedImagesDir, to: currentImagesURL)
+            } else {
+                try fileManager.createDirectory(at: currentImagesURL, withIntermediateDirectories: true)
+            }
+            progress(0.5)
+
+            ThumbnailCache.shared.clearAll()
+
+            let currentRealm = try Realm(configuration: realmManager.createConfiguration())
+            try currentRealm.write {
+                currentRealm.deleteAll()
+                for backupCard in backupCards {
+                    currentRealm.create(Card.self, value: backupCard, update: .all)
+                }
+            }
+            progress(0.8)
+
+            try? fileManager.removeItem(at: imagesBackupURL)
+            progress(1.0)
+
+            logger.notice("Backup imported: \(backupCards.count) cards")
+        } catch {
+            logger.error("Import failed, restoring images: \(error.localizedDescription)")
+
+            try? fileManager.removeItem(at: currentImagesURL)
+            if fileManager.fileExists(atPath: imagesBackupURL.path) {
+                try? fileManager.moveItem(at: imagesBackupURL, to: currentImagesURL)
+            }
+
+            throw BackupError.importFailed(error)
+        }
+    }
+
+    // MARK: - Import Preparation
+
+    func prepareForImport(from url: URL) throws -> (tempURL: URL, metadata: BackupMetadata) {
+        let shouldAccess = url.startAccessingSecurityScopedResource()
+        defer { if shouldAccess { url.stopAccessingSecurityScopedResource() } }
+
+        let tempURL = fileManager.temporaryDirectory.appendingPathComponent(url.lastPathComponent)
+        try? fileManager.removeItem(at: tempURL)
+        try fileManager.copyItem(at: url, to: tempURL)
+        let metadata = try validateBackup(at: tempURL)
+        return (tempURL, metadata)
+    }
+
+    // MARK: - Private Helpers
+
+    private static let fileDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyyMMdd_HHmmss"
+        return formatter
+    }()
+
+    private func migrateAllLegacyImages() throws {
+        let realm = try Realm(configuration: realmManager.createConfiguration())
+        let legacyCards = realm.objects(Card.self).filter("imagePath == nil AND editedImageData != nil")
+
+        guard !legacyCards.isEmpty else { return }
+
+        logger.notice("Migrating \(legacyCards.count) legacy images to disk")
+
+        for card in legacyCards {
+            autoreleasepool {
+                guard let imageData = card.editedImageData else { return }
+                let format = card.imageFormat ?? "jpeg"
+                do {
+                    let fileName = try ImageFileManager.shared.saveImageFile(data: imageData, cardId: card.id, format: format)
+                    try realm.write {
+                        card.imagePath = fileName
+                        card.editedImageData = nil
+                    }
+                } catch {
+                    logger.error("Legacy migration failed for card \(card.id): \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+
+    private func imageFilesInDirectory() throws -> [URL] {
+        guard fileManager.fileExists(atPath: cardImagesDirectory.path) else { return [] }
+        return try fileManager.contentsOfDirectory(at: cardImagesDirectory, includingPropertiesForKeys: nil)
+    }
+
+}

--- a/Sahara/Common/Manager/RealmManager.swift
+++ b/Sahara/Common/Manager/RealmManager.swift
@@ -33,6 +33,7 @@ protocol RealmManagerProtocol {
     func observeCards(inFolder folderName: String?) -> Observable<[CardListItemDTO]>
     func fetchImageData(for cardId: ObjectId) -> Data?
     func deleteCard(forPrimaryKey key: ObjectId) -> Observable<Void>
+    func createConfiguration() -> Realm.Configuration
 }
 
 extension RealmManagerProtocol {
@@ -109,6 +110,10 @@ final class RealmManager: RealmManagerProtocol {
             let url = directory.appendingPathComponent("default.\(ext)")
             try? fm.removeItem(at: url)
         }
+    }
+
+    func createConfiguration() -> Realm.Configuration {
+        Self.createConfiguration()
     }
 
     static func createConfiguration(schemaVersion: UInt64 = currentSchemaVersion, migrationBlock: MigrationBlock? = nil) -> Realm.Configuration {
@@ -608,5 +613,11 @@ final class MockRealmManager: RealmManagerProtocol {
 
     func deleteCard(forPrimaryKey key: ObjectId) -> Observable<Void> {
         return delete(Card.self, forPrimaryKey: key)
+    }
+
+    func createConfiguration() -> Realm.Configuration {
+        var config = Realm.Configuration.defaultConfiguration
+        config.inMemoryIdentifier = "MockRealm"
+        return config
     }
 }

--- a/Sahara/Common/Model/BackupMetadata.swift
+++ b/Sahara/Common/Model/BackupMetadata.swift
@@ -1,0 +1,39 @@
+//
+//  BackupMetadata.swift
+//  Sahara
+//
+//  Created by 금가경 on 3/8/26.
+//
+
+import Foundation
+import UIKit
+
+struct BackupMetadata: Codable {
+    let appVersion: String
+    let schemaVersion: UInt64
+    let cardCount: Int
+    let createdAt: Date
+    let deviceModel: String
+
+    static func create(cardCount: Int) -> BackupMetadata {
+        BackupMetadata(
+            appVersion: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown",
+            schemaVersion: RealmManager.currentSchemaVersion,
+            cardCount: cardCount,
+            createdAt: Date(),
+            deviceModel: DeviceInfo.modelIdentifier
+        )
+    }
+}
+
+enum DeviceInfo {
+    static var modelIdentifier: String {
+        var systemInfo = utsname()
+        uname(&systemInfo)
+        return withUnsafePointer(to: &systemInfo.machine) {
+            $0.withMemoryRebound(to: CChar.self, capacity: 1) {
+                String(validatingUTF8: $0) ?? UIDevice.current.model
+            }
+        }
+    }
+}

--- a/Sahara/Common/Utility/ThumbnailCache.swift
+++ b/Sahara/Common/Utility/ThumbnailCache.swift
@@ -147,6 +147,17 @@ final class ThumbnailCache {
 
     // MARK: - Invalidation
 
+    func clearAll() {
+        smallCache.removeAllObjects()
+        mediumCache.removeAllObjects()
+        serialQueue.sync {
+            inFlightRequests.removeAll()
+            aspectRatioCache.removeAll()
+        }
+        try? FileManager.default.removeItem(at: cacheDirectory)
+        try? FileManager.default.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
+    }
+
     func invalidate(for cardId: ObjectId) {
         for size in [ThumbnailSize.small, .medium] {
             let key = cacheKey(cardId: cardId, size: size)

--- a/Sahara/Feature/Settings/SettingsMenuItem.swift
+++ b/Sahara/Feature/Settings/SettingsMenuItem.swift
@@ -9,6 +9,9 @@ import Foundation
 
 enum SettingsMenuItem: CaseIterable {
     case language
+    case exportPhotos
+    case exportBackup
+    case importBackup
     case serviceNews
     case contactDeveloper
     case releaseNotes
@@ -18,6 +21,12 @@ enum SettingsMenuItem: CaseIterable {
         switch self {
         case .language:
             return NSLocalizedString("settings.language", comment: "")
+        case .exportPhotos:
+            return NSLocalizedString("settings.export_photos", comment: "")
+        case .exportBackup:
+            return NSLocalizedString("settings.export_backup", comment: "")
+        case .importBackup:
+            return NSLocalizedString("settings.import_backup", comment: "")
         case .serviceNews:
             return NSLocalizedString("settings.service_news", comment: "")
         case .contactDeveloper:
@@ -44,7 +53,7 @@ enum SettingsMenuItem: CaseIterable {
 
     var isSelectable: Bool {
         switch self {
-        case .language, .contactDeveloper, .releaseNotes:
+        case .language, .contactDeveloper, .releaseNotes, .exportPhotos, .exportBackup, .importBackup:
             return true
         case .serviceNews, .versionInfo:
             return false

--- a/Sahara/Feature/Settings/SettingsSection.swift
+++ b/Sahara/Feature/Settings/SettingsSection.swift
@@ -10,6 +10,7 @@ import RxDataSources
 
 enum SettingsSectionType {
     case general
+    case dataManagement
     case notifications
     case support
     case about
@@ -18,6 +19,8 @@ enum SettingsSectionType {
         switch self {
         case .general:
             return NSLocalizedString("settings.section_general", comment: "")
+        case .dataManagement:
+            return NSLocalizedString("settings.section_data", comment: "")
         case .notifications:
             return NSLocalizedString("settings.section_notifications", comment: "")
         case .support:

--- a/Sahara/Feature/Settings/SettingsViewController.swift
+++ b/Sahara/Feature/Settings/SettingsViewController.swift
@@ -11,6 +11,7 @@ import RxDataSources
 import RxSwift
 import SnapKit
 import UIKit
+import UniformTypeIdentifiers
 
 final class SettingsViewController: UIViewController {
     private let viewModel: SettingsViewModel
@@ -151,6 +152,24 @@ final class SettingsViewController: UIViewController {
                 owner.navigationController?.pushViewController(releaseNotesVC, animated: true)
             }
             .disposed(by: disposeBag)
+
+        output.exportPhotos
+            .drive(with: self) { owner, _ in
+                owner.performExport(using: BackupManager.shared.exportPhotosOnly)
+            }
+            .disposed(by: disposeBag)
+
+        output.exportBackup
+            .drive(with: self) { owner, _ in
+                owner.performExport(using: BackupManager.shared.exportBackup)
+            }
+            .disposed(by: disposeBag)
+
+        output.importBackup
+            .drive(with: self) { owner, _ in
+                owner.presentDocumentPicker()
+            }
+            .disposed(by: disposeBag)
     }
 
     private func presentMailComposer(to email: String) {
@@ -185,17 +204,7 @@ final class SettingsViewController: UIViewController {
     }
 
     private func getDeviceModel() -> String {
-        var systemInfo = utsname()
-        uname(&systemInfo)
-        let modelCode = withUnsafePointer(to: &systemInfo.machine) {
-            $0.withMemoryRebound(to: CChar.self, capacity: 1) {
-                String(validatingUTF8: $0)
-            }
-        }
-
-        guard let code = modelCode else {
-            return UIDevice.current.model
-        }
+        let code = DeviceInfo.modelIdentifier
 
         let deviceModelMap: [String: String] = [
             "iPhone14,2": "iPhone 13 Pro",
@@ -252,6 +261,65 @@ final class SettingsViewController: UIViewController {
         }
     }
 
+    // MARK: - Backup & Restore
+
+    private func performExport(using operation: @escaping (@escaping (Double) -> Void) throws -> URL) {
+        let progressAlert = createProgressAlert(title: NSLocalizedString("backup.exporting", comment: ""))
+        present(progressAlert.alert, animated: true)
+
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            do {
+                let url = try operation { progress in
+                    DispatchQueue.main.async {
+                        progressAlert.progressView.setProgress(Float(progress), animated: true)
+                    }
+                }
+                DispatchQueue.main.async {
+                    progressAlert.alert.dismiss(animated: true) {
+                        self?.presentShareSheet(for: url)
+                    }
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    progressAlert.alert.dismiss(animated: true) {
+                        self?.showBackupError(title: NSLocalizedString("backup.export_failed", comment: ""), error: error)
+                    }
+                }
+            }
+        }
+    }
+
+    private func presentDocumentPicker() {
+        let saharaType = UTType("com.miya.sahara.backup") ?? .data
+        let picker = UIDocumentPickerViewController(forOpeningContentTypes: [saharaType])
+        picker.delegate = self
+        picker.allowsMultipleSelection = false
+        present(picker, animated: true)
+    }
+
+    private func createProgressAlert(title: String) -> (alert: UIAlertController, progressView: UIProgressView) {
+        UIAlertController.progressAlert(title: title)
+    }
+
+    private func presentShareSheet(for url: URL) {
+        let activityVC = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+        if let popover = activityVC.popoverPresentationController {
+            popover.sourceView = view
+            popover.sourceRect = CGRect(x: view.bounds.midX, y: view.bounds.midY, width: 0, height: 0)
+        }
+        present(activityVC, animated: true)
+    }
+
+    private func showBackupError(title: String, error: Error) {
+        let alert = UIAlertController(
+            title: title,
+            message: error.localizedDescription,
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: NSLocalizedString("common.ok", comment: ""), style: .default))
+        present(alert, animated: true)
+    }
+
     private func showSettingsAlert() {
         let alert = UIAlertController(
             title: NSLocalizedString("settings.notification_denied_title", comment: ""),
@@ -290,5 +358,91 @@ extension SettingsViewController: UICollectionViewDelegateFlowLayout {
 extension SettingsViewController: MFMailComposeViewControllerDelegate {
     func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
         controller.dismiss(animated: true)
+    }
+}
+
+extension SettingsViewController: UIDocumentPickerDelegate {
+    func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+        guard let url = urls.first else { return }
+
+        do {
+            let (tempURL, metadata) = try BackupManager.shared.prepareForImport(from: url)
+            showImportConfirmation(metadata: metadata, fileURL: tempURL)
+        } catch {
+            showBackupError(title: NSLocalizedString("backup.import_failed", comment: ""), error: error)
+        }
+    }
+
+    private func showImportConfirmation(metadata: BackupMetadata, fileURL: URL) {
+        let title = NSLocalizedString("backup.confirm_import_title", comment: "")
+        let message = String(
+            format: NSLocalizedString("backup.confirm_import_message", comment: ""),
+            metadata.cardCount
+        )
+
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(
+            title: NSLocalizedString("backup.confirm_import_action", comment: ""),
+            style: .destructive
+        ) { [weak self] _ in
+            self?.performImport(from: fileURL)
+        })
+        alert.addAction(UIAlertAction(
+            title: NSLocalizedString("common.cancel", comment: ""),
+            style: .cancel
+        ))
+        present(alert, animated: true)
+    }
+
+    private func performImport(from url: URL) {
+        let progressAlert = createProgressAlert(title: NSLocalizedString("backup.importing", comment: ""))
+        present(progressAlert.alert, animated: true)
+
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            do {
+                try BackupManager.shared.importBackup(from: url) { progress in
+                    DispatchQueue.main.async {
+                        progressAlert.progressView.setProgress(Float(progress), animated: true)
+                    }
+                }
+                DispatchQueue.main.async {
+                    progressAlert.alert.dismiss(animated: true) {
+                        guard let self else { return }
+                        let alert = UIAlertController(
+                            title: NSLocalizedString("backup.import_success", comment: ""),
+                            message: nil,
+                            preferredStyle: .alert
+                        )
+                        alert.addAction(UIAlertAction(
+                            title: NSLocalizedString("common.ok", comment: ""),
+                            style: .default
+                        ))
+                        self.present(alert, animated: true)
+                    }
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    progressAlert.alert.dismiss(animated: true) {
+                        self?.showBackupError(
+                            title: NSLocalizedString("backup.import_failed", comment: ""),
+                            error: error
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+extension UIAlertController {
+    static func progressAlert(title: String) -> (alert: UIAlertController, progressView: UIProgressView) {
+        let alert = UIAlertController(title: title, message: "\n\n", preferredStyle: .alert)
+        let progressView = UIProgressView(progressViewStyle: .default)
+        alert.view.addSubview(progressView)
+        progressView.snp.makeConstraints { make in
+            make.horizontalEdges.equalToSuperview().inset(20)
+            make.bottom.equalToSuperview().inset(45)
+        }
+        return (alert, progressView)
     }
 }

--- a/Sahara/Feature/Settings/SettingsViewModel.swift
+++ b/Sahara/Feature/Settings/SettingsViewModel.swift
@@ -22,11 +22,15 @@ final class SettingsViewModel: BaseViewModelProtocol {
         let openLanguageSelection: Driver<Void>
         let openMailComposer: Driver<String>
         let openReleaseNotes: Driver<Void>
+        let exportPhotos: Driver<Void>
+        let exportBackup: Driver<Void>
+        let importBackup: Driver<Void>
     }
 
     func transform(input: Input) -> Output {
         let defaultSections = [
             SettingsSection(type: .general, items: [.language]),
+            SettingsSection(type: .dataManagement, items: [.exportPhotos, .exportBackup, .importBackup]),
             SettingsSection(type: .notifications, items: [.serviceNews]),
             SettingsSection(type: .support, items: [.contactDeveloper]),
             SettingsSection(type: .about, items: [.releaseNotes, .versionInfo])
@@ -36,44 +40,30 @@ final class SettingsViewModel: BaseViewModelProtocol {
             .map { _ in defaultSections }
             .asDriver(onErrorJustReturn: defaultSections)
 
-        let openLanguageSelection = input.itemSelected
-            .compactMap { item in
-                switch item {
-                case .language:
-                    return ()
-                default:
-                    return nil
-                }
-            }
-            .asDriver(onErrorDriveWith: .empty())
-
+        let openLanguageSelection = input.itemSelected.whenSelected(.language)
         let openMailComposer = input.itemSelected
-            .compactMap { item in
-                switch item {
-                case .contactDeveloper:
-                    return DeveloperConfig.developerEmail
-                default:
-                    return nil
-                }
-            }
+            .compactMap { $0 == .contactDeveloper ? DeveloperConfig.developerEmail : nil }
             .asDriver(onErrorDriveWith: .empty())
-
-        let openReleaseNotes = input.itemSelected
-            .compactMap { item in
-                switch item {
-                case .releaseNotes:
-                    return ()
-                default:
-                    return nil
-                }
-            }
-            .asDriver(onErrorDriveWith: .empty())
+        let openReleaseNotes = input.itemSelected.whenSelected(.releaseNotes)
+        let exportPhotos = input.itemSelected.whenSelected(.exportPhotos)
+        let exportBackup = input.itemSelected.whenSelected(.exportBackup)
+        let importBackup = input.itemSelected.whenSelected(.importBackup)
 
         return Output(
             sections: sections,
             openLanguageSelection: openLanguageSelection,
             openMailComposer: openMailComposer,
-            openReleaseNotes: openReleaseNotes
+            openReleaseNotes: openReleaseNotes,
+            exportPhotos: exportPhotos,
+            exportBackup: exportBackup,
+            importBackup: importBackup
         )
+    }
+}
+
+private extension Observable where Element == SettingsMenuItem {
+    func whenSelected(_ target: SettingsMenuItem) -> Driver<Void> {
+        compactMap { $0 == target ? () : nil }
+            .asDriver(onErrorDriveWith: .empty())
     }
 }

--- a/Sahara/Info.plist
+++ b/Sahara/Info.plist
@@ -45,6 +45,44 @@
 	<string></string>
 	<key>NSUserNotificationsUsageDescription</key>
 	<string></string>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<false/>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+				<string>public.archive</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Sahara Backup</string>
+			<key>UTTypeIdentifier</key>
+			<string>com.miya.sahara.backup</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>sahara</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Sahara Backup</string>
+			<key>CFBundleTypeRole</key>
+			<string>Owner</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.miya.sahara.backup</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleLocalizations</key>

--- a/Sahara/Resources/en.lproj/Localizable.strings
+++ b/Sahara/Resources/en.lproj/Localizable.strings
@@ -198,6 +198,23 @@
 "settings.app_version" = "App Version";
 "settings.ios_version" = "iOS Version";
 "settings.device_model" = "Device Model";
+"settings.section_data" = "Data Management";
+"settings.export_photos" = "Export Photos";
+"settings.export_backup" = "App Backup";
+"settings.import_backup" = "Import Backup";
+
+/* Backup */
+"backup.exporting" = "Creating backup...";
+"backup.importing" = "Restoring data...";
+"backup.confirm_import_title" = "Restore Data";
+"backup.confirm_import_message" = "Your current data will be replaced with the backup data (%d cards). Continue?";
+"backup.confirm_import_action" = "Restore";
+"backup.export_success" = "Backup created";
+"backup.import_success" = "Data restored";
+"backup.export_failed" = "Backup failed";
+"backup.import_failed" = "Restore failed";
+"backup.invalid_file" = "Invalid backup file";
+"backup.version_mismatch" = "This backup was created by a newer version of the app. Please update the app.";
 
 /* Realm Error */
 "realm_error.title" = "Unable to Load Data";

--- a/Sahara/Resources/ja.lproj/Localizable.strings
+++ b/Sahara/Resources/ja.lproj/Localizable.strings
@@ -198,6 +198,23 @@
 "settings.app_version" = "アプリバージョン";
 "settings.ios_version" = "iOSバージョン";
 "settings.device_model" = "デバイスモデル";
+"settings.section_data" = "データ管理";
+"settings.export_photos" = "写真をエクスポート";
+"settings.export_backup" = "アプリバックアップ";
+"settings.import_backup" = "バックアップをインポート";
+
+/* Backup */
+"backup.exporting" = "バックアップ作成中...";
+"backup.importing" = "データ復元中...";
+"backup.confirm_import_title" = "データ復元";
+"backup.confirm_import_message" = "現在のデータがバックアップデータ（%d枚のカード）に置き換えられます。続けますか？";
+"backup.confirm_import_action" = "復元";
+"backup.export_success" = "バックアップ作成完了";
+"backup.import_success" = "データ復元完了";
+"backup.export_failed" = "バックアップ作成失敗";
+"backup.import_failed" = "データ復元失敗";
+"backup.invalid_file" = "無効なバックアップファイルです";
+"backup.version_mismatch" = "このバックアップは新しいバージョンのアプリで作成されました。アプリをアップデートしてください。";
 
 /* Realm Error */
 "realm_error.title" = "データを読み込めません";

--- a/Sahara/Resources/ko.lproj/Localizable.strings
+++ b/Sahara/Resources/ko.lproj/Localizable.strings
@@ -198,6 +198,23 @@
 "settings.app_version" = "앱 버전";
 "settings.ios_version" = "iOS 버전";
 "settings.device_model" = "기기 모델";
+"settings.section_data" = "데이터 관리";
+"settings.export_photos" = "사진 내보내기";
+"settings.export_backup" = "앱 백업";
+"settings.import_backup" = "백업 가져오기";
+
+/* Backup */
+"backup.exporting" = "백업 생성 중...";
+"backup.importing" = "데이터 복원 중...";
+"backup.confirm_import_title" = "데이터 복원";
+"backup.confirm_import_message" = "현재 데이터가 백업 파일의 데이터(%d개의 카드)로 교체됩니다. 계속하시겠어요?";
+"backup.confirm_import_action" = "복원";
+"backup.export_success" = "백업 생성 완료";
+"backup.import_success" = "데이터 복원 완료";
+"backup.export_failed" = "백업 생성 실패";
+"backup.import_failed" = "데이터 복원 실패";
+"backup.invalid_file" = "올바르지 않은 백업 파일입니다";
+"backup.version_mismatch" = "이 백업 파일은 최신 버전의 앱에서 생성되었습니다. 앱을 업데이트해주세요.";
 
 /* Realm Error */
 "realm_error.title" = "데이터를 불러올 수 없습니다";

--- a/Sahara/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sahara/Resources/zh-Hans.lproj/Localizable.strings
@@ -192,6 +192,23 @@
 "settings.mail_error_message" = "邮件应用不可用";
 "settings.notification_denied_title" = "需要通知设置";
 "settings.notification_denied_message" = "请在设置中启用通知";
+"settings.section_data" = "数据管理";
+"settings.export_photos" = "导出照片";
+"settings.export_backup" = "应用备份";
+"settings.import_backup" = "导入备份";
+
+/* Backup */
+"backup.exporting" = "正在创建备份...";
+"backup.importing" = "正在恢复数据...";
+"backup.confirm_import_title" = "恢复数据";
+"backup.confirm_import_message" = "当前数据将被备份数据（%d张卡片）替换。是否继续？";
+"backup.confirm_import_action" = "恢复";
+"backup.export_success" = "备份创建完成";
+"backup.import_success" = "数据恢复完成";
+"backup.export_failed" = "备份创建失败";
+"backup.import_failed" = "数据恢复失败";
+"backup.invalid_file" = "无效的备份文件";
+"backup.version_mismatch" = "此备份由较新版本的应用创建，请更新应用。";
 
 /* Realm Error */
 "realm_error.title" = "无法加载数据";

--- a/Sahara/SceneDelegate.swift
+++ b/Sahara/SceneDelegate.swift
@@ -31,6 +31,15 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window?.rootViewController = mainTabBarController
 
         window?.makeKeyAndVisible()
+
+        if let urlContext = connectionOptions.urlContexts.first {
+            handleBackupFileImport(url: urlContext.url)
+        }
+    }
+
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        guard let urlContext = URLContexts.first else { return }
+        handleBackupFileImport(url: urlContext.url)
     }
 
     private func showRealmFailureAlert(on viewController: UIViewController) {
@@ -108,6 +117,98 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {
+    }
+
+    private func handleBackupFileImport(url: URL) {
+        do {
+            let (tempURL, metadata) = try BackupManager.shared.prepareForImport(from: url)
+            showImportConfirmation(metadata: metadata, fileURL: tempURL)
+        } catch {
+            showImportError(error)
+        }
+    }
+
+    private func showImportConfirmation(metadata: BackupMetadata, fileURL: URL) {
+        guard let rootVC = window?.rootViewController else { return }
+
+        let title = NSLocalizedString("backup.confirm_import_title", comment: "")
+        let message = String(
+            format: NSLocalizedString("backup.confirm_import_message", comment: ""),
+            metadata.cardCount
+        )
+
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(
+            title: NSLocalizedString("backup.confirm_import_action", comment: ""),
+            style: .destructive
+        ) { _ in
+            self.performImport(from: fileURL)
+        })
+        alert.addAction(UIAlertAction(
+            title: NSLocalizedString("common.cancel", comment: ""),
+            style: .cancel
+        ))
+
+        let presenter = rootVC.presentedViewController ?? rootVC
+        presenter.present(alert, animated: true)
+    }
+
+    private func performImport(from url: URL) {
+        guard let rootVC = window?.rootViewController else { return }
+
+        let progressAlert = UIAlertController.progressAlert(
+            title: NSLocalizedString("backup.importing", comment: "")
+        )
+
+        let presenter = rootVC.presentedViewController ?? rootVC
+        presenter.present(progressAlert.alert, animated: true)
+
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            do {
+                try BackupManager.shared.importBackup(from: url) { progress in
+                    DispatchQueue.main.async {
+                        progressAlert.progressView.setProgress(Float(progress), animated: true)
+                    }
+                }
+                DispatchQueue.main.async {
+                    progressAlert.alert.dismiss(animated: true) {
+                        self?.showImportSuccess()
+                    }
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    progressAlert.alert.dismiss(animated: true) {
+                        self?.showImportError(error)
+                    }
+                }
+            }
+        }
+    }
+
+    private func showImportSuccess() {
+        guard let rootVC = window?.rootViewController else { return }
+        let alert = UIAlertController(
+            title: NSLocalizedString("backup.import_success", comment: ""),
+            message: nil,
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(
+            title: NSLocalizedString("common.ok", comment: ""),
+            style: .default
+        ))
+        rootVC.present(alert, animated: true)
+    }
+
+    private func showImportError(_ error: Error) {
+        guard let rootVC = window?.rootViewController else { return }
+        let presenter = rootVC.presentedViewController ?? rootVC
+        let alert = UIAlertController(
+            title: NSLocalizedString("backup.import_failed", comment: ""),
+            message: error.localizedDescription,
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: NSLocalizedString("common.ok", comment: ""), style: .default))
+        presenter.present(alert, animated: true)
     }
 
     func handleNotification(type: String, userInfo: [AnyHashable: Any]) {

--- a/SaharaTests/BackupManagerTests.swift
+++ b/SaharaTests/BackupManagerTests.swift
@@ -1,0 +1,171 @@
+import XCTest
+import RealmSwift
+import ZIPFoundation
+@testable import Sahara
+
+final class BackupManagerTests: XCTestCase {
+    var tempDir: URL!
+    var testRealmURL: URL!
+    var testImagesDir: URL!
+    var backupManager: BackupManager!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("backup-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+        testRealmURL = tempDir.appendingPathComponent("default.realm")
+        testImagesDir = tempDir.appendingPathComponent("CardImages")
+        try FileManager.default.createDirectory(at: testImagesDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        backupManager = nil
+        if let tempDir = tempDir {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+        tempDir = nil
+        testRealmURL = nil
+        testImagesDir = nil
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Validate Tests
+
+    /// 올바른 구조의 백업 ZIP에서 metadata를 정상 파싱하는지 검증.
+    /// schemaVersion, cardCount 등이 저장한 값과 일치해야 한다.
+    func test_validateBackup_validFile_returnsMetadata() throws {
+        let archiveURL = try createTestBackupArchive(
+            schemaVersion: RealmManager.currentSchemaVersion,
+            cardCount: 5
+        )
+
+        let metadata = try BackupManager.shared.validateBackup(at: archiveURL)
+
+        XCTAssertEqual(metadata.schemaVersion, RealmManager.currentSchemaVersion)
+        XCTAssertEqual(metadata.cardCount, 5)
+        XCTAssertFalse(metadata.appVersion.isEmpty)
+    }
+
+    /// metadata.json이 없는 일반 ZIP 파일을 .sahara로 변경했을 때 거부하는지 검증.
+    /// 사용자가 임의의 ZIP을 .sahara로 변경한 경우를 대비.
+    func test_validateBackup_missingMetadata_throwsError() throws {
+        let archiveURL = tempDir.appendingPathComponent("invalid.sahara")
+        let archive = try Archive(url: archiveURL, accessMode: .create)
+
+        let dummyData = Data("dummy".utf8)
+        try archive.addEntry(with: "some_file.txt", type: .file, uncompressedSize: Int64(dummyData.count)) { position, size in
+            dummyData.subdata(in: Int(position)..<Int(position)+size)
+        }
+
+        XCTAssertThrowsError(try BackupManager.shared.validateBackup(at: archiveURL)) { error in
+            guard let backupError = error as? BackupError else {
+                XCTFail("Expected BackupError, got \(error)")
+                return
+            }
+            if case .missingMetadata = backupError {
+                // Expected
+            } else {
+                XCTFail("Expected missingMetadata, got \(backupError)")
+            }
+        }
+    }
+
+    /// 앱 다운그레이드 후 이전(상위 스키마) 백업을 복원하려 할 때 거부하는지 검증.
+    /// Realm은 역마이그레이션을 지원하지 않으므로 상위 스키마 백업은 열 수 없다.
+    func test_validateBackup_futureSchemaVersion_throwsError() throws {
+        let futureVersion = RealmManager.currentSchemaVersion + 10
+        let archiveURL = try createTestBackupArchive(
+            schemaVersion: futureVersion,
+            cardCount: 1
+        )
+
+        XCTAssertThrowsError(try BackupManager.shared.validateBackup(at: archiveURL)) { error in
+            guard let backupError = error as? BackupError else {
+                XCTFail("Expected BackupError, got \(error)")
+                return
+            }
+            if case .incompatibleSchemaVersion(let backup, let current) = backupError {
+                XCTAssertEqual(backup, futureVersion)
+                XCTAssertEqual(current, RealmManager.currentSchemaVersion)
+            } else {
+                XCTFail("Expected incompatibleSchemaVersion, got \(backupError)")
+            }
+        }
+    }
+
+    /// metadata.json은 있지만 default.realm이 없는 ZIP을 거부하는지 검증.
+    /// 손상되거나 불완전한 백업 파일 대비.
+    func test_validateBackup_missingRealm_throwsError() throws {
+        let archiveURL = tempDir.appendingPathComponent("no-realm.sahara")
+        let archive = try Archive(url: archiveURL, accessMode: .create)
+
+        let metadata = BackupMetadata(
+            appVersion: "1.0.0",
+            schemaVersion: RealmManager.currentSchemaVersion,
+            cardCount: 0,
+            createdAt: Date(),
+            deviceModel: "test"
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let metadataData = try encoder.encode(metadata)
+
+        try archive.addEntry(with: "metadata.json", type: .file, uncompressedSize: Int64(metadataData.count)) { position, size in
+            metadataData.subdata(in: Int(position)..<Int(position)+size)
+        }
+
+        XCTAssertThrowsError(try BackupManager.shared.validateBackup(at: archiveURL)) { error in
+            guard let backupError = error as? BackupError else {
+                XCTFail("Expected BackupError, got \(error)")
+                return
+            }
+            if case .missingRealmFile = backupError {
+                // Expected
+            } else {
+                XCTFail("Expected missingRealmFile, got \(backupError)")
+            }
+        }
+    }
+
+    /// BackupMetadata.create()가 현재 앱 정보를 올바르게 캡처하는지 검증.
+    /// 앱 버전, 스키마 버전, 디바이스 모델이 비어있지 않아야 한다.
+    func test_backupMetadata_create_capturesCurrentInfo() {
+        let metadata = BackupMetadata.create(cardCount: 42)
+
+        XCTAssertEqual(metadata.schemaVersion, RealmManager.currentSchemaVersion)
+        XCTAssertEqual(metadata.cardCount, 42)
+        XCTAssertFalse(metadata.deviceModel.isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    private func createTestBackupArchive(schemaVersion: UInt64, cardCount: Int) throws -> URL {
+        let archiveURL = tempDir.appendingPathComponent("test-backup-\(UUID().uuidString).sahara")
+        let archive = try Archive(url: archiveURL, accessMode: .create)
+
+        let metadata = BackupMetadata(
+            appVersion: "2.0.0",
+            schemaVersion: schemaVersion,
+            cardCount: cardCount,
+            createdAt: Date(),
+            deviceModel: "TestDevice"
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let metadataData = try encoder.encode(metadata)
+
+        try archive.addEntry(with: "metadata.json", type: .file, uncompressedSize: Int64(metadataData.count)) { position, size in
+            metadataData.subdata(in: Int(position)..<Int(position)+size)
+        }
+
+        let realmData = Data("fake-realm-data".utf8)
+        try archive.addEntry(with: "default.realm", type: .file, uncompressedSize: Int64(realmData.count)) { position, size in
+            realmData.subdata(in: Int(position)..<Int(position)+size)
+        }
+
+        return archiveURL
+    }
+}

--- a/SaharaTests/Mocks/MockRealmManager.swift
+++ b/SaharaTests/Mocks/MockRealmManager.swift
@@ -129,6 +129,12 @@ final class MockRealmManager: RealmManagerProtocol {
         return delete(Card.self, forPrimaryKey: key)
     }
 
+    func createConfiguration() -> Realm.Configuration {
+        var config = Realm.Configuration.defaultConfiguration
+        config.inMemoryIdentifier = "MockRealm"
+        return config
+    }
+
     func reset() {
         addCalled = false
         fetchCalled = false


### PR DESCRIPTION
Closes #42

## 변경 내용

**추가**
- ZIPFoundation 의존성 추가
- 백업 매니저: 사진만 내보내기(ZIP), 전체 백업 내보내기/가져오기(.sahara 포맷) 지원
- 백업 메타데이터 모델: 앱 버전, 스키마 버전, 카드 수, 디바이스 정보 저장
- `.sahara` Custom UTType 등록 — 파일 앱/AirDrop에서 직접 열기 지원
- SceneDelegate에서 .sahara 파일 URL 수신 시 자동 import flow 시작
- 설정 화면에 데이터 관리 섹션 (사진 내보내기 / 앱 백업 / 백업 가져오기)
- 썸네일 캐시 전체 삭제 기능 (import 시 사용)
- RealmManagerProtocol에 createConfiguration() 추가 — BackupManager DI 지원
- 백업 검증 테스트 (유효 파일, 누락 메타데이터, 미래 스키마, 누락 Realm)
- 4개 언어 로컬라이제이션 (한국어, 영어, 일본어, 중국어)

**수정**
- SettingsViewModel의 메뉴 선택 로직을 whenSelected 헬퍼로 리팩토링
- SettingsViewController의 디바이스 모델 조회를 DeviceInfo로 통합
- ThumbnailCache.clearAll()을 디렉토리 삭제+재생성 방식으로 개선
- RealmManager.configuration을 var에서 let으로 변경

## 결정 근거

- **데이터 복사 방식** — Realm 파일을 직접 swap하면 기존 Realm 참조가 무효화되어 크래시 위험. deleteAll + create 루프로 열린 상태에서 안전하게 교체
- **레거시 마이그레이션 선행** — export 전 editedImageData를 디스크 파일로 마이그레이션하여 백업 파일에 바이너리 포함 방지
- **import 롤백 전략** — 이미지 디렉토리를 .bak으로 백업 후 교체, Realm write 실패 시 catch에서 수동 복원
- **Security-Scoped Resource** — Document Picker/URL open의 외부 파일을 즉시 tmp로 복사 후 접근 해제, 이후 작업은 복사본으로 수행