### PR TITLE
Add basic iPad compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,15 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             -resultBundlePath TestResults
 
+      - name: Build for iPad
+        run: |
+          xcodebuild build \
+            -scheme ${{ steps.scheme.outputs.name }} \
+            -configuration Debug \
+            -destination 'platform=iOS Simulator,name=iPad (10th generation),OS=18.2' \
+            -skipPackagePluginValidation \
+            CODE_SIGNING_ALLOWED=NO
+
       - name: Upload Test Results
         if: failure()
         uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test build help
+.PHONY: test test-ipad build help
 
 CLI_DERIVED_DATA = .build
 
@@ -24,6 +24,16 @@ test:
 		-skipPackagePluginValidation \
 		CODE_SIGNING_ALLOWED=NO
 
+test-ipad:
+	@echo "Branch: $(BRANCH) → Scheme: $(SCHEME) (iPad)"
+	xcodebuild test \
+		-scheme $(SCHEME) \
+		-configuration Debug \
+		-destination 'platform=iOS Simulator,name=iPad (10th generation),OS=18.2' \
+		-derivedDataPath $(CLI_DERIVED_DATA) \
+		-skipPackagePluginValidation \
+		CODE_SIGNING_ALLOWED=NO
+
 build:
 	@echo "Branch: $(BRANCH) → Scheme: $(SCHEME)"
 	xcodebuild build \
@@ -35,9 +45,10 @@ build:
 		CODE_SIGNING_ALLOWED=NO
 
 help:
-	@echo "make test   - Run full test suite locally"
-	@echo "make build  - Build without running tests"
-	@echo "make help   - Show this help"
+	@echo "make test      - Run full test suite locally (iPhone)"
+	@echo "make test-ipad - Run full test suite locally (iPad)"
+	@echo "make build     - Build without running tests"
+	@echo "make help      - Show this help"
 	@echo ""
 	@echo "Branch: $(BRANCH) → Scheme: $(SCHEME)"
 	@echo "Override: make test SCHEME=Sahara"

--- a/Sahara.xcodeproj/project.pbxproj
+++ b/Sahara.xcodeproj/project.pbxproj
@@ -351,7 +351,7 @@
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Sahara.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Sahara";
 			};
 			name = Debug;
@@ -374,7 +374,7 @@
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Sahara.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Sahara";
 			};
 			name = Release;
@@ -401,6 +401,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UIRequiresFullScreen = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
@@ -418,7 +419,7 @@
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -443,6 +444,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UIRequiresFullScreen = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
@@ -460,7 +462,7 @@
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};

--- a/Sahara/Common/Layout/GridLayout.swift
+++ b/Sahara/Common/Layout/GridLayout.swift
@@ -8,12 +8,14 @@
 import UIKit
 
 final class GridLayout: UICollectionViewFlowLayout {
-    private let numberOfColumns: Int
+    private(set) var numberOfColumns: Int
     private let cellSpacing: CGFloat
+    private let minColumnWidth: CGFloat?
 
-    init(numberOfColumns: Int, cellSpacing: CGFloat) {
+    init(numberOfColumns: Int, cellSpacing: CGFloat, minColumnWidth: CGFloat? = nil) {
         self.numberOfColumns = numberOfColumns
         self.cellSpacing = cellSpacing
+        self.minColumnWidth = minColumnWidth
         super.init()
 
         self.minimumInteritemSpacing = cellSpacing
@@ -31,6 +33,11 @@ final class GridLayout: UICollectionViewFlowLayout {
         guard let collectionView = collectionView else { return }
 
         let availableWidth = collectionView.bounds.width - sectionInset.left - sectionInset.right
+
+        if let minColumnWidth = minColumnWidth {
+            numberOfColumns = max(2, Int(availableWidth / minColumnWidth))
+        }
+
         let totalSpacing = cellSpacing * CGFloat(numberOfColumns - 1)
         let itemWidth = ((availableWidth - totalSpacing) / CGFloat(numberOfColumns)).rounded(.down)
 

--- a/Sahara/Common/Layout/PinterestLayout.swift
+++ b/Sahara/Common/Layout/PinterestLayout.swift
@@ -6,7 +6,6 @@
 //
 
 import UIKit
-import UIKit
 
 protocol PinterestLayoutDelegate: AnyObject {
     func collectionView(
@@ -15,11 +14,13 @@ protocol PinterestLayoutDelegate: AnyObject {
 }
 
 class PinterestLayout: UICollectionViewFlowLayout {
-    
+
     weak var delegate: PinterestLayoutDelegate?
-    
+
+    private(set) var columnCount: Int = 2
+
     private var contentHeight: CGFloat = 0
-    
+
     private var contentWidth: CGFloat {
         guard let collectionView = collectionView else {
             return 0
@@ -27,13 +28,13 @@ class PinterestLayout: UICollectionViewFlowLayout {
         let insets = collectionView.contentInset
         return collectionView.bounds.width - (insets.left + insets.right)
     }
-    
+
     private var cache: [UICollectionViewLayoutAttributes] = []
-    
+
     override var collectionViewContentSize: CGSize {
         return CGSize(width: contentWidth, height: contentHeight)
     }
-    
+
     override func prepare() {
         guard let collectionView = collectionView else { return }
 
@@ -42,12 +43,12 @@ class PinterestLayout: UICollectionViewFlowLayout {
 
         guard contentWidth > 0 else { return }
 
-        let numberOfColumns: Int = 2
+        columnCount = max(2, Int(contentWidth / 180))
         let cellPadding: CGFloat = 4
-        let cellWidth: CGFloat = contentWidth / CGFloat(numberOfColumns)
+        let cellWidth: CGFloat = contentWidth / CGFloat(columnCount)
 
-        let xOffSet: [CGFloat] = [0, cellWidth]
-        var yOffSet: [CGFloat] = .init(repeating: 0, count: numberOfColumns)
+        let xOffSet: [CGFloat] = (0..<columnCount).map { CGFloat($0) * cellWidth }
+        var yOffSet: [CGFloat] = .init(repeating: 0, count: columnCount)
 
         var column: Int = 0
 
@@ -72,23 +73,23 @@ class PinterestLayout: UICollectionViewFlowLayout {
             contentHeight = max(contentHeight, frame.maxY)
             yOffSet[column] = yOffSet[column] + height
 
-            column = yOffSet[0] > yOffSet[1] ? 1 : 0
+            column = yOffSet.enumerated().min(by: { $0.element < $1.element })?.offset ?? 0
         }
     }
-    
+
     override func layoutAttributesForElements(in rect: CGRect)
     -> [UICollectionViewLayoutAttributes]? {
         var visibleLayoutAttributes: [UICollectionViewLayoutAttributes] = []
-        
+
         for attributes in cache {
             if attributes.frame.intersects(rect) {
                 visibleLayoutAttributes.append(attributes)
             }
         }
-        
+
         return visibleLayoutAttributes
     }
-    
+
     override func layoutAttributesForItem(at indexPath: IndexPath)
     -> UICollectionViewLayoutAttributes? {
         return cache[indexPath.item]

--- a/Sahara/Feature/CardDetail/CardDetailViewController.swift
+++ b/Sahara/Feature/CardDetail/CardDetailViewController.swift
@@ -37,7 +37,7 @@ final class CardDetailViewController: UIViewController {
     }()
 
     private lazy var photoCardView: PhotoCardView = {
-        let cardWidth = view.bounds.width - 64
+        let cardWidth = min(view.bounds.width - 64, 500)
         return PhotoCardView(cardWidth: cardWidth)
     }()
 
@@ -157,7 +157,9 @@ final class CardDetailViewController: UIViewController {
 
         photoCardView.snp.makeConstraints { make in
             make.top.equalToSuperview().offset(32)
-            make.horizontalEdges.equalToSuperview().inset(32)
+            make.centerX.equalToSuperview()
+            make.width.lessThanOrEqualTo(500)
+            make.horizontalEdges.equalToSuperview().inset(32).priority(.medium)
         }
 
         buttonContainerView.snp.makeConstraints { make in

--- a/Sahara/Feature/CardInfo/CardInfoCoordinator.swift
+++ b/Sahara/Feature/CardInfo/CardInfoCoordinator.swift
@@ -107,8 +107,8 @@ final class CardInfoCoordinator: Coordinator, CardInfoCoordinatorProtocol {
 
         var navController: UINavigationController?
 
-        if let tabBarController = presentingVC as? UITabBarController {
-            navController = tabBarController.selectedViewController as? UINavigationController
+        if let mainTabBar = presentingVC as? MainTabBarController {
+            navController = mainTabBar.selectedViewController as? UINavigationController
         } else if let nav = presentingVC as? UINavigationController {
             navController = nav
         } else {

--- a/Sahara/Feature/CardInfo/CardInfoViewController.swift
+++ b/Sahara/Feature/CardInfo/CardInfoViewController.swift
@@ -125,12 +125,14 @@ final class CardInfoViewController: UIViewController {
 
         contentView.snp.makeConstraints { make in
             make.top.equalTo(customNavigationBar.snp.bottom)
-            make.horizontalEdges.bottom.equalTo(view.safeAreaLayoutGuide)
+            make.centerX.equalToSuperview()
+            make.width.lessThanOrEqualTo(600)
+            make.horizontalEdges.equalTo(view.safeAreaLayoutGuide).priority(.medium)
+            make.bottom.equalTo(view.safeAreaLayoutGuide)
         }
 
         contentView.scrollView.snp.remakeConstraints { make in
-            make.top.equalTo(customNavigationBar.snp.bottom)
-            make.horizontalEdges.bottom.equalTo(view.safeAreaLayoutGuide)
+            make.edges.equalToSuperview()
         }
     }
 

--- a/Sahara/Feature/CardInfo/MediaSelectionViewController.swift
+++ b/Sahara/Feature/CardInfo/MediaSelectionViewController.swift
@@ -34,13 +34,7 @@ final class MediaSelectionViewController: UIViewController {
     private let imagePickerResultRelay = PublishRelay<(ImageSourceData, CLLocation?, Date?, MediaSource)>()
 
     private lazy var collectionView: UICollectionView = {
-        let layout = UICollectionViewFlowLayout()
-        let spacing: CGFloat = 2
-        let width = (view.bounds.width - spacing * 4) / 3
-        layout.itemSize = CGSize(width: width, height: width)
-        layout.minimumInteritemSpacing = spacing
-        layout.minimumLineSpacing = spacing
-        layout.sectionInset = UIEdgeInsets(top: spacing, left: spacing, bottom: spacing, right: spacing)
+        let layout = GridLayout(numberOfColumns: 3, cellSpacing: 2, minColumnWidth: 110)
 
         let cv = UICollectionView(frame: .zero, collectionViewLayout: layout)
         cv.backgroundColor = .clear

--- a/Sahara/Feature/Gallery/CardList/CardListViewController.swift
+++ b/Sahara/Feature/Gallery/CardList/CardListViewController.swift
@@ -282,7 +282,7 @@ extension CardListViewController: PinterestLayoutDelegate {
             return 180
         }
 
-        let columnWidth = collectionView.bounds.width / 2
+        let columnWidth = collectionView.bounds.width / CGFloat(pinterestLayout.columnCount)
         let calculatedHeight = columnWidth * aspectRatio
 
         return calculatedHeight.isFinite && calculatedHeight > 0 ? calculatedHeight : 180

--- a/Sahara/Feature/Gallery/Tab/Folder/FolderViewController.swift
+++ b/Sahara/Feature/Gallery/Tab/Folder/FolderViewController.swift
@@ -16,7 +16,7 @@ final class FolderViewController: UIViewController {
     private let viewWillAppearRelay = PublishRelay<Void>()
 
     private lazy var collectionView: UICollectionView = {
-        let layout = GridLayout(numberOfColumns: 2, cellSpacing: 8)
+        let layout = GridLayout(numberOfColumns: 2, cellSpacing: 8, minColumnWidth: 160)
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.register(FolderCell.self, forCellWithReuseIdentifier: FolderCell.identifier)
         collectionView.backgroundColor = .clear

--- a/Sahara/Feature/Search/SearchViewController.swift
+++ b/Sahara/Feature/Search/SearchViewController.swift
@@ -190,7 +190,7 @@ extension SearchViewController: PinterestLayoutDelegate {
         guard size.width > 0 else { return 180 }
 
         let aspectRatio = size.height / size.width
-        let cellWidth = (collectionView.bounds.width - 8) / 2
+        let cellWidth = collectionView.bounds.width / CGFloat(pinterestLayout.columnCount) - 8
         return cellWidth * aspectRatio
     }
 }

--- a/Sahara/Feature/Settings/SettingsViewController.swift
+++ b/Sahara/Feature/Settings/SettingsViewController.swift
@@ -78,7 +78,9 @@ final class SettingsViewController: UIViewController {
 
         collectionView.snp.makeConstraints { make in
             make.top.equalTo(customNavigationBar.snp.bottom).offset(20)
-            make.horizontalEdges.equalToSuperview().inset(20)
+            make.centerX.equalToSuperview()
+            make.width.lessThanOrEqualTo(600)
+            make.horizontalEdges.equalToSuperview().inset(20).priority(.medium)
             make.bottom.equalTo(view.safeAreaLayoutGuide)
         }
     }

--- a/Sahara/Feature/Stats/StatsViewController.swift
+++ b/Sahara/Feature/Stats/StatsViewController.swift
@@ -179,8 +179,10 @@ final class StatsViewController: UIViewController {
         }
 
         contentStackView.snp.makeConstraints { make in
-            make.edges.equalToSuperview().inset(20)
-            make.width.equalTo(scrollView.snp.width).offset(-40)
+            make.top.bottom.equalToSuperview().inset(20)
+            make.centerX.equalToSuperview()
+            make.width.lessThanOrEqualTo(600)
+            make.width.equalTo(scrollView.snp.width).offset(-40).priority(.medium)
         }
 
         basicStatsStackView.snp.makeConstraints { make in

--- a/Sahara/Feature/Tab/MainTabBarController.swift
+++ b/Sahara/Feature/Tab/MainTabBarController.swift
@@ -8,7 +8,22 @@
 import UIKit
 import SnapKit
 
-final class MainTabBarController: UITabBarController {
+final class MainTabBarController: UIViewController {
+    private var childNavigationControllers: [UINavigationController] = []
+
+    var selectedIndex: Int = 0 {
+        didSet {
+            guard oldValue != selectedIndex,
+                  !childNavigationControllers.isEmpty else { return }
+            switchTab(from: oldValue, to: selectedIndex)
+        }
+    }
+
+    var selectedViewController: UIViewController? {
+        guard selectedIndex < childNavigationControllers.count else { return nil }
+        return childNavigationControllers[selectedIndex]
+    }
+
     private let customTabBar: UIView = {
         let view = UIView()
         return view
@@ -68,7 +83,6 @@ final class MainTabBarController: UITabBarController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        tabBar.isHidden = true
         setupCustomTabBar()
         setupViewControllers()
     }
@@ -101,7 +115,9 @@ final class MainTabBarController: UITabBarController {
         }
 
         tabButtonStackView.snp.makeConstraints { make in
-            make.horizontalEdges.equalToSuperview().inset(48)
+            make.centerX.equalToSuperview()
+            make.width.lessThanOrEqualTo(400)
+            make.horizontalEdges.equalToSuperview().inset(48).priority(.medium)
             make.bottom.equalTo(view.safeAreaLayoutGuide).offset(-8)
         }
 
@@ -132,32 +148,51 @@ final class MainTabBarController: UITabBarController {
         let settingsVC = SettingsViewController(viewModel: settingsVM)
         let settingsNav = UINavigationController(rootViewController: settingsVC)
 
-        viewControllers = [galleryNav, searchNav, statsNav, settingsNav]
+        childNavigationControllers = [galleryNav, searchNav, statsNav, settingsNav]
+
+        let firstNav = childNavigationControllers[0]
+        addChild(firstNav)
+        view.insertSubview(firstNav.view, belowSubview: customTabBar)
+        firstNav.view.frame = view.bounds
+        firstNav.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        firstNav.didMove(toParent: self)
+
+        updateTabSelection()
+    }
+
+    private func switchTab(from oldIndex: Int, to newIndex: Int) {
+        let fromNav = childNavigationControllers[oldIndex]
+        fromNav.willMove(toParent: nil)
+        fromNav.view.removeFromSuperview()
+        fromNav.removeFromParent()
+
+        let toNav = childNavigationControllers[newIndex]
+        addChild(toNav)
+        view.insertSubview(toNav.view, belowSubview: customTabBar)
+        toNav.view.frame = view.bounds
+        toNav.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        toNav.didMove(toParent: self)
 
         updateTabSelection()
     }
 
     @objc private func galleryTabTapped() {
         selectedIndex = 0
-        updateTabSelection()
         AnalyticsManager.shared.logTabSelected(tabName: "gallery")
     }
 
     @objc private func searchTabTapped() {
         selectedIndex = 1
-        updateTabSelection()
         AnalyticsManager.shared.logTabSelected(tabName: "search")
     }
 
     @objc private func statsTabTapped() {
         selectedIndex = 2
-        updateTabSelection()
         AnalyticsManager.shared.logTabSelected(tabName: "stats")
     }
 
     @objc private func settingsTabTapped() {
         selectedIndex = 3
-        updateTabSelection()
         AnalyticsManager.shared.logTabSelected(tabName: "settings")
     }
 


### PR DESCRIPTION
Closes #44

## 변경 내용

**추가**
- iPad 기본 호환 지원 (Portrait only, Multitasking 비활성화)
- 레이아웃 동적 컬럼 계산 — iPad 화면 너비에 따라 갤러리/폴더/미디어 선택 컬럼 수 자동 조정
- 카드 상세(500pt), 탭바(400pt), 콘텐츠 영역(600pt) max-width 제약으로 iPad에서 과도한 가로 확장 방지
- Makefile `test-ipad` 타겟, CI iPad 빌드 검증 스텝

**수정**
- MainTabBarController를 UITabBarController에서 UIViewController로 전환하여 iPadOS 18 시스템 탭바 간섭 제거
- 미디어 선택 화면의 수동 FlowLayout을 GridLayout으로 교체

## 결정 근거

- **UIViewController 전환** — iPadOS 18에서 UITabBarController가 상단에 시스템 탭바를 자동 표시하며, mode = .tabBar로도 숨길 수 없어서 커스텀 탭 바만 사용하는 구조로 전환
- **max-width 인라인 적용** — 대상 VC가 3개뿐이므로 헬퍼 추출 없이 각 VC에 직접 적용
- **CI 빌드만 추가** — iPad 테스트는 디바이스 독립적이므로 iPhone에서 실행하고, iPad는 빌드 성공만 검증