### PR TITLE
Add Mac Catalyst support

### DIFF
--- a/Sahara.xcodeproj/project.pbxproj
+++ b/Sahara.xcodeproj/project.pbxproj
@@ -346,7 +346,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.miya.SaharaTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MACCATALYST = YES;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -369,7 +369,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.miya.SaharaTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MACCATALYST = YES;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -400,8 +400,8 @@
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "카드를 만들기 위해 사진 라이브러리 접근 권한을 허용해주세요.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UIRequiresFullScreen = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
@@ -410,11 +410,12 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.miya.Sahara.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MACCATALYST = YES;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -443,8 +444,8 @@
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "카드를 만들기 위해 사진 라이브러리 접근 권한을 허용해주세요.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UIRequiresFullScreen = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
@@ -453,11 +454,12 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.miya.Sahara;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MACCATALYST = YES;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Sahara/Common/Extension/UIView+Gradient.swift
+++ b/Sahara/Common/Extension/UIView+Gradient.swift
@@ -15,9 +15,7 @@ extension UIView {
 
         let gradientLayer = CAGradientLayer()
         gradientLayer.frame = bounds
-        #if targetEnvironment(macCatalyst)
-        gradientLayer.autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
-        #endif
+        configureLayerForResizableWindow(gradientLayer)
         gradientLayer.colors = gradient.colors
         gradientLayer.locations = gradient.locations
         gradientLayer.startPoint = gradient.startPoint
@@ -35,10 +33,14 @@ extension UIView {
         let patternLayer = CALayer()
         patternLayer.backgroundColor = UIColor(patternImage: patternImage).cgColor
         patternLayer.frame = bounds
-        #if targetEnvironment(macCatalyst)
-        patternLayer.autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
-        #endif
+        configureLayerForResizableWindow(patternLayer)
         layer.insertSublayer(patternLayer, at: 1)
+    }
+
+    private func configureLayerForResizableWindow(_ layer: CALayer) {
+        #if targetEnvironment(macCatalyst)
+        layer.autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
+        #endif
     }
 
     func applyGradientWithDots(_ gradient: DesignToken.Gradient, dotSize: CGFloat, spacing: CGFloat, dotColor: UIColor) {

--- a/Sahara/Common/Extension/UIView+Gradient.swift
+++ b/Sahara/Common/Extension/UIView+Gradient.swift
@@ -15,6 +15,9 @@ extension UIView {
 
         let gradientLayer = CAGradientLayer()
         gradientLayer.frame = bounds
+        #if targetEnvironment(macCatalyst)
+        gradientLayer.autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
+        #endif
         gradientLayer.colors = gradient.colors
         gradientLayer.locations = gradient.locations
         gradientLayer.startPoint = gradient.startPoint
@@ -23,25 +26,19 @@ extension UIView {
     }
 
     func applyDotPattern(dotSize: CGFloat, spacing: CGFloat, color: UIColor) {
-        let dotLayer = CAShapeLayer()
-        dotLayer.frame = bounds
-
-        let dotPath = UIBezierPath()
-
-        var y: CGFloat = 0
-        while y < bounds.height {
-            var x: CGFloat = 0
-            while x < bounds.width {
-                let dotRect = CGRect(x: x, y: y, width: dotSize, height: dotSize)
-                dotPath.append(UIBezierPath(ovalIn: dotRect))
-                x += spacing
-            }
-            y += spacing
+        let tileSize = CGSize(width: spacing, height: spacing)
+        let renderer = UIGraphicsImageRenderer(size: tileSize)
+        let patternImage = renderer.image { ctx in
+            ctx.cgContext.setFillColor(color.cgColor)
+            ctx.cgContext.fillEllipse(in: CGRect(x: 0, y: 0, width: dotSize, height: dotSize))
         }
-
-        dotLayer.path = dotPath.cgPath
-        dotLayer.fillColor = color.cgColor
-        layer.insertSublayer(dotLayer, at: 1)
+        let patternLayer = CALayer()
+        patternLayer.backgroundColor = UIColor(patternImage: patternImage).cgColor
+        patternLayer.frame = bounds
+        #if targetEnvironment(macCatalyst)
+        patternLayer.autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
+        #endif
+        layer.insertSublayer(patternLayer, at: 1)
     }
 
     func applyGradientWithDots(_ gradient: DesignToken.Gradient, dotSize: CGFloat, spacing: CGFloat, dotColor: UIColor) {

--- a/Sahara/Common/Manager/PermissionManager.swift
+++ b/Sahara/Common/Manager/PermissionManager.swift
@@ -69,10 +69,8 @@ final class PermissionManager {
         alert.addAction(UIAlertAction(
             title: NSLocalizedString("media_selection.go_to_settings", comment: ""),
             style: .default
-        ) { _ in
-            if let url = URL(string: UIApplication.openSettingsURLString) {
-                UIApplication.shared.open(url)
-            }
+        ) { [weak self] _ in
+            self?.openSettings(for: type)
         })
 
         alert.addAction(UIAlertAction(
@@ -81,6 +79,27 @@ final class PermissionManager {
         ))
 
         viewController.present(alert, animated: true)
+    }
+
+    private func openSettings(for type: PermissionType) {
+        #if targetEnvironment(macCatalyst)
+        let urlString: String
+        switch type {
+        case .photoLibrary:
+            urlString = "x-apple.systempreferences:com.apple.preference.security?Privacy_Photos"
+        case .camera:
+            urlString = "x-apple.systempreferences:com.apple.preference.security?Privacy_Camera"
+        case .location:
+            urlString = "x-apple.systempreferences:com.apple.preference.security?Privacy_LocationServices"
+        }
+        if let url = URL(string: urlString) {
+            UIApplication.shared.open(url)
+        }
+        #else
+        if let url = URL(string: UIApplication.openSettingsURLString) {
+            UIApplication.shared.open(url)
+        }
+        #endif
     }
 
     private func checkCameraPermission() -> PermissionStatus {

--- a/Sahara/Common/Model/BackupMetadata.swift
+++ b/Sahara/Common/Model/BackupMetadata.swift
@@ -21,7 +21,7 @@ struct BackupMetadata: Codable {
             schemaVersion: RealmManager.currentSchemaVersion,
             cardCount: cardCount,
             createdAt: Date(),
-            deviceModel: DeviceInfo.modelIdentifier
+            deviceModel: DeviceInfo.displayName
         )
     }
 }
@@ -35,5 +35,41 @@ enum DeviceInfo {
                 String(validatingUTF8: $0) ?? UIDevice.current.model
             }
         }
+    }
+
+    static var displayName: String {
+        #if targetEnvironment(macCatalyst)
+        var size: size_t = 0
+        sysctlbyname("hw.model", nil, &size, nil, 0)
+        var model = [CChar](repeating: 0, count: size)
+        sysctlbyname("hw.model", &model, &size, nil, 0)
+        return String(cString: model)
+        #else
+        let code = modelIdentifier
+
+        let deviceModelMap: [String: String] = [
+            "iPhone14,2": "iPhone 13 Pro",
+            "iPhone14,3": "iPhone 13 Pro Max",
+            "iPhone14,4": "iPhone 13 mini",
+            "iPhone14,5": "iPhone 13",
+            "iPhone14,6": "iPhone SE (3rd generation)",
+            "iPhone14,7": "iPhone 14",
+            "iPhone14,8": "iPhone 14 Plus",
+            "iPhone15,2": "iPhone 14 Pro",
+            "iPhone15,3": "iPhone 14 Pro Max",
+            "iPhone15,4": "iPhone 15",
+            "iPhone15,5": "iPhone 15 Plus",
+            "iPhone16,1": "iPhone 15 Pro",
+            "iPhone16,2": "iPhone 15 Pro Max",
+            "iPhone17,1": "iPhone 16 Pro",
+            "iPhone17,2": "iPhone 16 Pro Max",
+            "iPhone17,3": "iPhone 16",
+            "iPhone17,4": "iPhone 16 Plus",
+            "arm64": "Simulator",
+            "x86_64": "Simulator"
+        ]
+
+        return deviceModelMap[code] ?? code
+        #endif
     }
 }

--- a/Sahara/Common/Utility/EXIFMetadataExtractor.swift
+++ b/Sahara/Common/Utility/EXIFMetadataExtractor.swift
@@ -1,0 +1,73 @@
+//
+//  EXIFMetadataExtractor.swift
+//  Sahara
+//
+
+import CoreLocation
+import ImageIO
+
+struct EXIFMetadata {
+    let location: CLLocation?
+    let date: Date?
+}
+
+enum EXIFMetadataExtractor {
+
+    private static let exifDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy:MM:dd HH:mm:ss"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        return formatter
+    }()
+
+    static func extract(from data: Data) -> EXIFMetadata {
+        let sourceOptions: [CFString: Any] = [kCGImageSourceShouldCache: false]
+        guard let source = CGImageSourceCreateWithData(data as CFData, sourceOptions as CFDictionary),
+              let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [String: Any] else {
+            return EXIFMetadata(location: nil, date: nil)
+        }
+
+        let date = parseDate(from: properties)
+        let location = parseLocation(from: properties)
+        return EXIFMetadata(location: location, date: date)
+    }
+
+    static func extract(from metadata: [String: Any]) -> EXIFMetadata {
+        let date = parseDate(from: metadata)
+        return EXIFMetadata(location: nil, date: date)
+    }
+
+    private static func parseDate(from properties: [String: Any]) -> Date? {
+        if let exifDict = properties[kCGImagePropertyExifDictionary as String] as? [String: Any] {
+            if let dateString = exifDict[kCGImagePropertyExifDateTimeOriginal as String] as? String {
+                return exifDateFormatter.date(from: dateString)
+            }
+            if let dateString = exifDict[kCGImagePropertyExifDateTimeDigitized as String] as? String {
+                return exifDateFormatter.date(from: dateString)
+            }
+        }
+
+        if let tiffDict = properties[kCGImagePropertyTIFFDictionary as String] as? [String: Any],
+           let dateString = tiffDict[kCGImagePropertyTIFFDateTime as String] as? String {
+            return exifDateFormatter.date(from: dateString)
+        }
+
+        return nil
+    }
+
+    private static func parseLocation(from properties: [String: Any]) -> CLLocation? {
+        guard let gpsDict = properties[kCGImagePropertyGPSDictionary as String] as? [String: Any],
+              let latitude = gpsDict[kCGImagePropertyGPSLatitude as String] as? Double,
+              let longitude = gpsDict[kCGImagePropertyGPSLongitude as String] as? Double else {
+            return nil
+        }
+
+        let latRef = gpsDict[kCGImagePropertyGPSLatitudeRef as String] as? String
+        let lonRef = gpsDict[kCGImagePropertyGPSLongitudeRef as String] as? String
+
+        let lat = (latRef == "S") ? -latitude : latitude
+        let lon = (lonRef == "W") ? -longitude : longitude
+
+        return CLLocation(latitude: lat, longitude: lon)
+    }
+}

--- a/Sahara/Feature/CardDetail/CardDetailViewController.swift
+++ b/Sahara/Feature/CardDetail/CardDetailViewController.swift
@@ -200,6 +200,29 @@ final class CardDetailViewController: UIViewController {
         present(navController, animated: true)
     }
 
+    private func bindSaveOutput(_ output: CardDetailViewModel.Output) {
+        #if targetEnvironment(macCatalyst)
+        output.saveFileURL
+            .drive(with: self) { owner, url in
+                let picker = UIDocumentPickerViewController(forExporting: [url])
+                owner.present(picker, animated: true)
+            }
+            .disposed(by: disposeBag)
+        #else
+        output.saveResult
+            .drive(with: self) { owner, result in
+                switch result {
+                case .success:
+                    let message = NSLocalizedString("photo_detail.save_success_message", comment: "")
+                    owner.showToast(message: message)
+                case .failure(let error):
+                    owner.showToast(message: error.localizedDescription)
+                }
+            }
+            .disposed(by: disposeBag)
+        #endif
+    }
+
     private func bind() {
         photoCardView.deleteButtonTappedRelay
             .bind(with: self) { owner, _ in
@@ -233,26 +256,7 @@ final class CardDetailViewController: UIViewController {
 
         let output = viewModel.transform(input: input)
 
-        #if targetEnvironment(macCatalyst)
-        output.saveFileURL
-            .drive(with: self) { owner, url in
-                let picker = UIDocumentPickerViewController(forExporting: [url])
-                owner.present(picker, animated: true)
-            }
-            .disposed(by: disposeBag)
-        #else
-        output.saveResult
-            .drive(with: self) { owner, result in
-                switch result {
-                case .success:
-                    let message = NSLocalizedString("photo_detail.save_success_message", comment: "")
-                    owner.showToast(message: message)
-                case .failure(let error):
-                    owner.showToast(message: error.localizedDescription)
-                }
-            }
-            .disposed(by: disposeBag)
-        #endif
+        bindSaveOutput(output)
 
         output.shareImage
             .drive(with: self) { owner, image in

--- a/Sahara/Feature/CardDetail/CardDetailViewController.swift
+++ b/Sahara/Feature/CardDetail/CardDetailViewController.swift
@@ -263,6 +263,7 @@ final class CardDetailViewController: UIViewController {
                 let itemSource = ShareActivityItemSource(image: image)
                 let activityVC = UIActivityViewController(activityItems: [itemSource], applicationActivities: nil)
                 activityVC.popoverPresentationController?.sourceView = owner.shareButton
+                activityVC.popoverPresentationController?.sourceRect = owner.shareButton.bounds
                 owner.present(activityVC, animated: true)
             }
             .disposed(by: disposeBag)

--- a/Sahara/Feature/CardDetail/CardDetailViewController.swift
+++ b/Sahara/Feature/CardDetail/CardDetailViewController.swift
@@ -233,6 +233,14 @@ final class CardDetailViewController: UIViewController {
 
         let output = viewModel.transform(input: input)
 
+        #if targetEnvironment(macCatalyst)
+        output.saveFileURL
+            .drive(with: self) { owner, url in
+                let picker = UIDocumentPickerViewController(forExporting: [url])
+                owner.present(picker, animated: true)
+            }
+            .disposed(by: disposeBag)
+        #else
         output.saveResult
             .drive(with: self) { owner, result in
                 switch result {
@@ -244,6 +252,7 @@ final class CardDetailViewController: UIViewController {
                 }
             }
             .disposed(by: disposeBag)
+        #endif
 
         output.shareImage
             .drive(with: self) { owner, image in

--- a/Sahara/Feature/CardDetail/CardDetailViewModel.swift
+++ b/Sahara/Feature/CardDetail/CardDetailViewModel.swift
@@ -27,6 +27,7 @@ final class CardDetailViewModel: BaseViewModelProtocol {
 
     struct Output {
         let saveResult: Driver<Result<Void, Error>>
+        let saveFileURL: Driver<URL>
         let shareImage: Driver<UIImage>
         let deleteCompleted: Driver<Void>
     }
@@ -50,6 +51,27 @@ final class CardDetailViewModel: BaseViewModelProtocol {
 
         let cardImage = cardImageRelay.compactMap { $0 }.asObservable()
 
+        #if targetEnvironment(macCatalyst)
+        let saveResult: Driver<Result<Void, Error>> = .empty()
+        let saveFileURL = input.saveButtonTapped
+            .withLatestFrom(cardImage)
+            .observe(on: ConcurrentDispatchQueueScheduler(qos: .userInitiated))
+            .compactMap { imageData -> URL? in
+                let ext = ImageFormatHelper.detect(from: imageData)?.rawValue ?? "jpeg"
+                let fileName = "Sahara_Photo_\(UUID().uuidString).\(ext)"
+                let tempURL = FileManager.default.temporaryDirectory
+                    .appendingPathComponent(fileName)
+                do {
+                    try imageData.write(to: tempURL)
+                    return tempURL
+                } catch {
+                    return nil
+                }
+            }
+            .observe(on: MainScheduler.instance)
+            .asDriver(onErrorDriveWith: .empty())
+        #else
+        let saveFileURL: Driver<URL> = .empty()
         let saveResult = input.saveButtonTapped
             .withLatestFrom(cardImage)
             .flatMap { imageData -> Observable<Result<Void, Error>> in
@@ -71,6 +93,7 @@ final class CardDetailViewModel: BaseViewModelProtocol {
                 }
             }
             .asDriver(onErrorJustReturn: .failure(NSError(domain: "CardDetailViewModel", code: -1, userInfo: [NSLocalizedDescriptionKey: NSLocalizedString("photo_detail.save_failed", comment: "")])))
+        #endif
 
         let shareImage = input.shareButtonTapped
             .withLatestFrom(cardImage)
@@ -93,6 +116,7 @@ final class CardDetailViewModel: BaseViewModelProtocol {
 
         return Output(
             saveResult: saveResult,
+            saveFileURL: saveFileURL,
             shareImage: shareImage,
             deleteCompleted: deleteCompleted
         )

--- a/Sahara/Feature/CardDetail/CardDetailViewModel.swift
+++ b/Sahara/Feature/CardDetail/CardDetailViewModel.swift
@@ -51,49 +51,11 @@ final class CardDetailViewModel: BaseViewModelProtocol {
 
         let cardImage = cardImageRelay.compactMap { $0 }.asObservable()
 
-        #if targetEnvironment(macCatalyst)
-        let saveResult: Driver<Result<Void, Error>> = .empty()
-        let saveFileURL = input.saveButtonTapped
-            .withLatestFrom(cardImage)
-            .observe(on: ConcurrentDispatchQueueScheduler(qos: .userInitiated))
-            .compactMap { imageData -> URL? in
-                let ext = ImageFormatHelper.detect(from: imageData)?.rawValue ?? "jpeg"
-                let fileName = "Sahara_Photo_\(UUID().uuidString).\(ext)"
-                let tempURL = FileManager.default.temporaryDirectory
-                    .appendingPathComponent(fileName)
-                do {
-                    try imageData.write(to: tempURL)
-                    return tempURL
-                } catch {
-                    return nil
-                }
-            }
-            .observe(on: MainScheduler.instance)
-            .asDriver(onErrorDriveWith: .empty())
-        #else
-        let saveFileURL: Driver<URL> = .empty()
-        let saveResult = input.saveButtonTapped
-            .withLatestFrom(cardImage)
-            .flatMap { imageData -> Observable<Result<Void, Error>> in
-                return Observable.create { observer in
-                    PHPhotoLibrary.shared().performChanges({
-                        let request = PHAssetCreationRequest.forAsset()
-                        request.addResource(with: .photo, data: imageData, options: nil)
-                    }) { success, error in
-                        if success {
-                            observer.onNext(.success(()))
-                        } else if let error = error {
-                            observer.onNext(.failure(error))
-                        } else {
-                            observer.onNext(.failure(NSError(domain: "CardDetailViewModel", code: -1, userInfo: [NSLocalizedDescriptionKey: NSLocalizedString("photo_detail.save_failed", comment: "")])))
-                        }
-                        observer.onCompleted()
-                    }
-                    return Disposables.create()
-                }
-            }
-            .asDriver(onErrorJustReturn: .failure(NSError(domain: "CardDetailViewModel", code: -1, userInfo: [NSLocalizedDescriptionKey: NSLocalizedString("photo_detail.save_failed", comment: "")])))
-        #endif
+        let saveAction = configureSaveAction(
+            trigger: input.saveButtonTapped, imageData: cardImage
+        )
+        let saveResult = saveAction.saveResult
+        let saveFileURL = saveAction.saveFileURL
 
         let shareImage = input.shareButtonTapped
             .withLatestFrom(cardImage)
@@ -120,5 +82,55 @@ final class CardDetailViewModel: BaseViewModelProtocol {
             shareImage: shareImage,
             deleteCompleted: deleteCompleted
         )
+    }
+
+    private func configureSaveAction(
+        trigger: Observable<Void>, imageData: Observable<Data>
+    ) -> (saveResult: Driver<Result<Void, Error>>, saveFileURL: Driver<URL>) {
+        #if targetEnvironment(macCatalyst)
+        let saveResult: Driver<Result<Void, Error>> = .empty()
+        let saveFileURL = trigger
+            .withLatestFrom(imageData)
+            .observe(on: ConcurrentDispatchQueueScheduler(qos: .userInitiated))
+            .compactMap { imageData -> URL? in
+                let ext = ImageFormatHelper.detect(from: imageData)?.rawValue ?? "jpeg"
+                let fileName = "Sahara_Photo_\(UUID().uuidString).\(ext)"
+                let tempURL = FileManager.default.temporaryDirectory
+                    .appendingPathComponent(fileName)
+                do {
+                    try imageData.write(to: tempURL)
+                    return tempURL
+                } catch {
+                    return nil
+                }
+            }
+            .observe(on: MainScheduler.instance)
+            .asDriver(onErrorDriveWith: .empty())
+        return (saveResult, saveFileURL)
+        #else
+        let saveFileURL: Driver<URL> = .empty()
+        let saveResult = trigger
+            .withLatestFrom(imageData)
+            .flatMap { imageData -> Observable<Result<Void, Error>> in
+                return Observable.create { observer in
+                    PHPhotoLibrary.shared().performChanges({
+                        let request = PHAssetCreationRequest.forAsset()
+                        request.addResource(with: .photo, data: imageData, options: nil)
+                    }) { success, error in
+                        if success {
+                            observer.onNext(.success(()))
+                        } else if let error = error {
+                            observer.onNext(.failure(error))
+                        } else {
+                            observer.onNext(.failure(NSError(domain: "CardDetailViewModel", code: -1, userInfo: [NSLocalizedDescriptionKey: NSLocalizedString("photo_detail.save_failed", comment: "")])))
+                        }
+                        observer.onCompleted()
+                    }
+                    return Disposables.create()
+                }
+            }
+            .asDriver(onErrorJustReturn: .failure(NSError(domain: "CardDetailViewModel", code: -1, userInfo: [NSLocalizedDescriptionKey: NSLocalizedString("photo_detail.save_failed", comment: "")])))
+        return (saveResult, saveFileURL)
+        #endif
     }
 }

--- a/Sahara/Feature/CardDetail/CardDetailViewModel.swift
+++ b/Sahara/Feature/CardDetail/CardDetailViewModel.swift
@@ -75,8 +75,9 @@ final class CardDetailViewModel: BaseViewModelProtocol {
         let shareImage = input.shareButtonTapped
             .withLatestFrom(cardImage)
             .compactMap { imageData -> UIImage? in
-                let screenScale = UIScreen.main.scale
-                let screenBounds = UIScreen.main.bounds
+                let screen = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.first?.screen
+                let screenScale = screen?.scale ?? 2.0
+                let screenBounds = screen?.bounds ?? CGRect(x: 0, y: 0, width: 393, height: 852)
                 let maxDim = max(screenBounds.width, screenBounds.height) * screenScale
                 return ImageDownsampler.downsample(data: imageData, maxDimension: maxDim)
             }

--- a/Sahara/Feature/CardDetail/PhotoCardViewModel.swift
+++ b/Sahara/Feature/CardDetail/PhotoCardViewModel.swift
@@ -63,8 +63,9 @@ final class PhotoCardViewModel: BaseViewModelProtocol {
 
         let photoImage = cardData
             .map { data -> UIImage? in
-                let screenScale = UIScreen.main.scale
-                let screenBounds = UIScreen.main.bounds
+                let screen = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.first?.screen
+                let screenScale = screen?.scale ?? 2.0
+                let screenBounds = screen?.bounds ?? CGRect(x: 0, y: 0, width: 393, height: 852)
                 let maxDim = max(screenBounds.width, screenBounds.height) * screenScale
                 return ImageDownsampler.downsample(data: data.image, maxDimension: maxDim)
             }

--- a/Sahara/Feature/CardInfo/CardInfoViewModel.swift
+++ b/Sahara/Feature/CardInfo/CardInfoViewModel.swift
@@ -88,8 +88,9 @@ final class CardInfoViewModel: BaseViewModelProtocol {
     }
 
     private func loadCardData(from card: Card, imageData: Data) {
-        let screenScale = UIScreen.main.scale
-        let screenBounds = UIScreen.main.bounds
+        let screen = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.first?.screen
+        let screenScale = screen?.scale ?? 2.0
+        let screenBounds = screen?.bounds ?? CGRect(x: 0, y: 0, width: 393, height: 852)
         let maxDim = max(screenBounds.width, screenBounds.height) * screenScale * 2
         self.editedImage = ImageDownsampler.downsample(data: imageData, maxDimension: maxDim)
         self.originalDate = card.date

--- a/Sahara/Feature/CardInfo/Component/Camera/CameraViewController.swift
+++ b/Sahara/Feature/CardInfo/Component/Camera/CameraViewController.swift
@@ -5,6 +5,7 @@
 //  Created by 금가경 on 10/1/25.
 //
 
+#if !targetEnvironment(macCatalyst)
 import AVFoundation
 import SnapKit
 import UIKit
@@ -173,3 +174,4 @@ extension CameraViewController: AVCapturePhotoCaptureDelegate {
         present(nav, animated: true)
     }
 }
+#endif

--- a/Sahara/Feature/CardInfo/Component/Camera/CameraViewController.swift
+++ b/Sahara/Feature/CardInfo/Component/Camera/CameraViewController.swift
@@ -5,7 +5,6 @@
 //  Created by 금가경 on 10/1/25.
 //
 
-#if !targetEnvironment(macCatalyst)
 import AVFoundation
 import SnapKit
 import UIKit
@@ -33,7 +32,24 @@ final class CameraViewController: UIViewController {
         return button
     }()
 
-    private var currentCamera: AVCaptureDevice.Position = .back
+    private let cancelButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage(systemName: "xmark"), for: .normal)
+        button.tintColor = .white
+        button.backgroundColor = UIColor.black.withAlphaComponent(0.3)
+        button.layer.cornerRadius = 20
+        return button
+    }()
+
+    private var currentCamera: AVCaptureDevice.Position = {
+        #if targetEnvironment(macCatalyst)
+        return .front
+        #else
+        return .back
+        #endif
+    }()
+
+    var onPhotoCaptured: ((ImageSourceData) -> Void)?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -57,7 +73,7 @@ final class CameraViewController: UIViewController {
 
         guard let captureSession = captureSession else { return }
 
-        guard let camera = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .back) else { return }
+        guard let camera = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: currentCamera) else { return }
 
         do {
             let input = try AVCaptureDeviceInput(device: camera)
@@ -86,6 +102,7 @@ final class CameraViewController: UIViewController {
 
         view.addSubview(captureButton)
         view.addSubview(flipCameraButton)
+        view.addSubview(cancelButton)
 
         captureButton.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
@@ -99,8 +116,24 @@ final class CameraViewController: UIViewController {
             make.width.height.equalTo(50)
         }
 
+        cancelButton.snp.makeConstraints { make in
+            make.leading.equalToSuperview().inset(30)
+            make.centerY.equalTo(captureButton)
+            make.width.height.equalTo(40)
+        }
+
         captureButton.addTarget(self, action: #selector(capturePhoto), for: .touchUpInside)
         flipCameraButton.addTarget(self, action: #selector(flipCamera), for: .touchUpInside)
+        cancelButton.addTarget(self, action: #selector(cancelTapped), for: .touchUpInside)
+
+        let discoverySession = AVCaptureDevice.DiscoverySession(
+            deviceTypes: [.builtInWideAngleCamera],
+            mediaType: .video,
+            position: .unspecified
+        )
+        if discoverySession.devices.count <= 1 {
+            flipCameraButton.isHidden = true
+        }
     }
 
     private func startSession() {
@@ -125,12 +158,10 @@ final class CameraViewController: UIViewController {
 
         captureSession.beginConfiguration()
 
-        // 현재 입력 제거
         if let currentInput = captureSession.inputs.first as? AVCaptureDeviceInput {
             captureSession.removeInput(currentInput)
         }
 
-        // 카메라 전환
         currentCamera = currentCamera == .back ? .front : .back
 
         guard let newCamera = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: currentCamera) else {
@@ -147,6 +178,10 @@ final class CameraViewController: UIViewController {
         }
 
         captureSession.commitConfiguration()
+    }
+
+    @objc private func cancelTapped() {
+        dismiss(animated: true)
     }
 
     override func viewDidLayoutSubviews() {
@@ -167,11 +202,8 @@ extension CameraViewController: AVCapturePhotoCaptureDelegate {
             format: format
         )
 
-        let stickerViewModel = MediaEditorViewModel(imageSource: imageSource)
-        let stickerVC = MediaEditorViewController(viewModel: stickerViewModel)
-        let nav = UINavigationController(rootViewController: stickerVC)
-        nav.modalPresentationStyle = .fullScreen
-        present(nav, animated: true)
+        dismiss(animated: true) { [weak self] in
+            self?.onPhotoCaptured?(imageSource)
+        }
     }
 }
-#endif

--- a/Sahara/Feature/CardInfo/Component/Camera/CameraViewController.swift
+++ b/Sahara/Feature/CardInfo/Component/Camera/CameraViewController.swift
@@ -75,7 +75,10 @@ final class CameraViewController: UIViewController {
 
         guard let captureSession = captureSession else { return }
 
-        guard let camera = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: currentCamera) else { return }
+        guard let camera = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: currentCamera) else {
+            showCameraUnavailableAlert()
+            return
+        }
 
         do {
             let input = try AVCaptureDeviceInput(device: camera)
@@ -96,7 +99,23 @@ final class CameraViewController: UIViewController {
                 view.layer.insertSublayer(previewLayer, at: 0)
             }
         } catch {
+            showCameraUnavailableAlert()
         }
+    }
+
+    private func showCameraUnavailableAlert() {
+        let alert = UIAlertController(
+            title: NSLocalizedString("camera.unavailable_title", comment: ""),
+            message: NSLocalizedString("camera.unavailable_message", comment: ""),
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(
+            title: NSLocalizedString("common.ok", comment: ""),
+            style: .default
+        ) { [weak self] _ in
+            self?.dismiss(animated: true)
+        })
+        present(alert, animated: true)
     }
 
     private func configureUI() {
@@ -177,6 +196,12 @@ final class CameraViewController: UIViewController {
                 captureSession.addInput(newInput)
             }
         } catch {
+            currentCamera = currentCamera == .back ? .front : .back
+            if let fallbackCamera = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: currentCamera),
+               let fallbackInput = try? AVCaptureDeviceInput(device: fallbackCamera),
+               captureSession.canAddInput(fallbackInput) {
+                captureSession.addInput(fallbackInput)
+            }
         }
 
         captureSession.commitConfiguration()

--- a/Sahara/Feature/CardInfo/Component/Camera/CameraViewController.swift
+++ b/Sahara/Feature/CardInfo/Component/Camera/CameraViewController.swift
@@ -41,13 +41,15 @@ final class CameraViewController: UIViewController {
         return button
     }()
 
-    private var currentCamera: AVCaptureDevice.Position = {
+    private lazy var currentCamera: AVCaptureDevice.Position = defaultCameraPosition
+
+    private var defaultCameraPosition: AVCaptureDevice.Position {
         #if targetEnvironment(macCatalyst)
         return .front
         #else
         return .back
         #endif
-    }()
+    }
 
     var onPhotoCaptured: ((ImageSourceData) -> Void)?
 

--- a/Sahara/Feature/CardInfo/Component/MediaEditor/Handler/MediaEditorImageHandler.swift
+++ b/Sahara/Feature/CardInfo/Component/MediaEditor/Handler/MediaEditorImageHandler.swift
@@ -31,8 +31,9 @@ final class MediaEditorImageHandler {
             hasAlpha = false
         }
 
+        let screenScale = photoImageView.window?.screen.scale ?? 2.0
         let format = UIGraphicsImageRendererFormat()
-        format.scale = UIScreen.main.scale
+        format.scale = screenScale
         format.opaque = !hasAlpha
 
         let renderer = UIGraphicsImageRenderer(size: imageRect.size, format: format)
@@ -44,7 +45,7 @@ final class MediaEditorImageHandler {
             photoImageView.layer.render(in: context.cgContext)
             stickerContainerView.layer.render(in: context.cgContext)
 
-            let drawingImage = canvasView.drawing.image(from: canvasView.bounds, scale: UIScreen.main.scale)
+            let drawingImage = canvasView.drawing.image(from: canvasView.bounds, scale: screenScale)
             drawingImage.draw(at: .zero)
         }
 
@@ -113,7 +114,8 @@ final class MediaEditorImageHandler {
             if let editorSize = editorViewSize {
                 viewSize = editorSize
             } else {
-                let standardCardWidth = min(UIScreen.main.bounds.width - 64, 400)
+                let screenWidth = (UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.first?.screen.bounds.width) ?? 393
+                let standardCardWidth = min(screenWidth - 64, 400)
                 viewSize = CGSize(width: standardCardWidth, height: standardCardWidth * 2)
             }
             let displayRect = MediaEditorCropHandler.calculateDisplayedImageRect(

--- a/Sahara/Feature/CardInfo/Component/MediaEditor/StickerCell.swift
+++ b/Sahara/Feature/CardInfo/Component/MediaEditor/StickerCell.swift
@@ -54,7 +54,7 @@ final class StickerCell: UICollectionViewCell, IsIdentifiable {
 
         if let urlString = urlString, let url = URL(string: urlString) {
             let options: KingfisherOptionsInfo = [
-                .scaleFactor(UIScreen.main.scale),
+                .scaleFactor(window?.screen.scale ?? 2.0),
                 .memoryCacheExpiration(.seconds(600)),
                 .diskCacheExpiration(.days(7)),
                 .cacheOriginalImage,

--- a/Sahara/Feature/CardInfo/Component/MediaEditor/View/AnimatedStickerView.swift
+++ b/Sahara/Feature/CardInfo/Component/MediaEditor/View/AnimatedStickerView.swift
@@ -37,7 +37,7 @@ final class AnimatedStickerView: UIView {
         }
 
         let options: KingfisherOptionsInfo = [
-            .scaleFactor(UIScreen.main.scale),
+            .scaleFactor(window?.screen.scale ?? 2.0),
             .memoryCacheExpiration(.seconds(600)),
             .diskCacheExpiration(.days(7)),
             .cacheOriginalImage,

--- a/Sahara/Feature/CardInfo/Component/MediaEditor/View/DraggableStickerView.swift
+++ b/Sahara/Feature/CardInfo/Component/MediaEditor/View/DraggableStickerView.swift
@@ -48,7 +48,7 @@ final class DraggableStickerView: BaseGestureView {
         if let urlString = urlString, let url = URL(string: urlString) {
             self.stickerURL = url
             let options: KingfisherOptionsInfo = [
-                .scaleFactor(UIScreen.main.scale),
+                .scaleFactor(window?.screen.scale ?? 2.0),
                 .memoryCacheExpiration(.seconds(600)),
                 .diskCacheExpiration(.days(7)),
                 .cacheOriginalImage,
@@ -62,7 +62,7 @@ final class DraggableStickerView: BaseGestureView {
         if let urlString = stickerDTO.resourceUrl, let url = URL(string: urlString) {
             self.stickerURL = url
             let options: KingfisherOptionsInfo = [
-                .scaleFactor(UIScreen.main.scale),
+                .scaleFactor(window?.screen.scale ?? 2.0),
                 .memoryCacheExpiration(.seconds(600)),
                 .diskCacheExpiration(.days(7)),
                 .cacheOriginalImage,

--- a/Sahara/Feature/CardInfo/MediaSelectionViewController.swift
+++ b/Sahara/Feature/CardInfo/MediaSelectionViewController.swift
@@ -109,26 +109,11 @@ final class MediaSelectionViewController: UIViewController {
                 let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
                 var actionItems: [MediaCollectionItem] = []
 
-                #if !targetEnvironment(macCatalyst)
-                if status == .authorized {
-                    actionItems.append(.action(
-                        icon: "camera.fill",
-                        title: NSLocalizedString("media_selection.camera", comment: ""),
-                        type: .camera
-                    ))
-                } else {
-                    actionItems.append(.action(
-                        icon: "camera.fill",
-                        title: NSLocalizedString("media_selection.camera", comment: ""),
-                        type: .camera
-                    ))
-                    actionItems.append(.action(
-                        icon: "photo.on.rectangle",
-                        title: NSLocalizedString("media_selection.library", comment: ""),
-                        type: .library
-                    ))
-                }
-                #else
+                actionItems.append(.action(
+                    icon: "camera.fill",
+                    title: NSLocalizedString("media_selection.camera", comment: ""),
+                    type: .camera
+                ))
                 if status != .authorized {
                     actionItems.append(.action(
                         icon: "photo.on.rectangle",
@@ -136,7 +121,6 @@ final class MediaSelectionViewController: UIViewController {
                         type: .library
                     ))
                 }
-                #endif
 
                 sections.append(SectionModel(model: "actions", items: actionItems))
 
@@ -164,13 +148,11 @@ final class MediaSelectionViewController: UIViewController {
             }
             .disposed(by: disposeBag)
 
-        #if !targetEnvironment(macCatalyst)
         output.showCamera
             .drive(with: self) { owner, _ in
                 owner.presentCamera()
             }
             .disposed(by: disposeBag)
-        #endif
 
         output.showPHPicker
             .drive(with: self) { owner, _ in
@@ -190,7 +172,6 @@ final class MediaSelectionViewController: UIViewController {
             }
             .disposed(by: disposeBag)
 
-        #if !targetEnvironment(macCatalyst)
         output.requestCameraPermission
             .drive(with: self) { owner, _ in
                 PermissionManager.shared.requestPermission(for: .camera, from: owner) { [weak owner] status in
@@ -203,7 +184,6 @@ final class MediaSelectionViewController: UIViewController {
                 }
             }
             .disposed(by: disposeBag)
-        #endif
 
         output.requestPhotoPermission
             .drive(with: self) { owner, _ in
@@ -230,16 +210,14 @@ final class MediaSelectionViewController: UIViewController {
             .disposed(by: disposeBag)
     }
 
-    #if !targetEnvironment(macCatalyst)
     private func presentCamera() {
-        guard UIImagePickerController.isSourceTypeAvailable(.camera) else { return }
-
-        let picker = UIImagePickerController()
-        picker.sourceType = .camera
-        picker.delegate = self
-        present(picker, animated: true)
+        let cameraVC = CameraViewController()
+        cameraVC.modalPresentationStyle = .fullScreen
+        cameraVC.onPhotoCaptured = { [weak self] imageSource in
+            self?.imagePickerResultRelay.accept((imageSource, nil, Date(), .camera))
+        }
+        present(cameraVC, animated: true)
     }
-    #endif
 
     private func presentPHPicker() {
         var configuration = PHPickerConfiguration(photoLibrary: .shared())
@@ -277,27 +255,6 @@ final class MediaSelectionViewController: UIViewController {
 
     @objc private func closeTapped() {
         dismiss(animated: true)
-    }
-}
-
-extension MediaSelectionViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
-    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
-        picker.dismiss(animated: true)
-
-        if let image = info[.originalImage] as? UIImage {
-            let metadata: EXIFMetadata
-            if let mediaMetadata = info[.mediaMetadata] as? [String: Any] {
-                metadata = EXIFMetadataExtractor.extract(from: mediaMetadata)
-            } else {
-                metadata = EXIFMetadata(location: nil, date: nil)
-            }
-            let imageSource = ImageSourceData(image: image)
-            imagePickerResultRelay.accept((imageSource, nil, metadata.date, .camera))
-        }
-    }
-
-    func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
-        picker.dismiss(animated: true)
     }
 }
 

--- a/Sahara/Feature/CardInfo/MediaSelectionViewController.swift
+++ b/Sahara/Feature/CardInfo/MediaSelectionViewController.swift
@@ -240,7 +240,7 @@ final class MediaSelectionViewController: UIViewController {
     #endif
 
     private func presentPHPicker() {
-        var configuration = PHPickerConfiguration()
+        var configuration = PHPickerConfiguration(photoLibrary: .shared())
         configuration.selectionLimit = 1
         configuration.filter = .images
 
@@ -283,8 +283,14 @@ extension MediaSelectionViewController: UIImagePickerControllerDelegate, UINavig
         picker.dismiss(animated: true)
 
         if let image = info[.originalImage] as? UIImage {
+            let metadata: EXIFMetadata
+            if let mediaMetadata = info[.mediaMetadata] as? [String: Any] {
+                metadata = EXIFMetadataExtractor.extract(from: mediaMetadata)
+            } else {
+                metadata = EXIFMetadata(location: nil, date: nil)
+            }
             let imageSource = ImageSourceData(image: image)
-            imagePickerResultRelay.accept((imageSource, nil, nil, .camera))
+            imagePickerResultRelay.accept((imageSource, nil, metadata.date, .camera))
         }
     }
 
@@ -297,7 +303,14 @@ extension MediaSelectionViewController: PHPickerViewControllerDelegate {
     func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
         picker.dismiss(animated: true)
 
-        guard let itemProvider = results.first?.itemProvider else { return }
+        guard let result = results.first else { return }
+        let itemProvider = result.itemProvider
+
+        let asset = result.assetIdentifier.flatMap { identifier in
+            PHAsset.fetchAssets(withLocalIdentifiers: [identifier], options: nil).firstObject
+        }
+        let assetDate = asset?.creationDate
+        let assetLocation = asset?.location
 
         let typeIdentifiers = itemProvider.registeredTypeIdentifiers
         let preferredType = typeIdentifiers.first ?? "public.image"
@@ -318,12 +331,17 @@ extension MediaSelectionViewController: PHPickerViewControllerDelegate {
                 let format = ImageFormatHelper.detectFromUTI(preferredType)
                     ?? ImageFormatHelper.detect(from: data)
 
+                let exifMetadata = EXIFMetadataExtractor.extract(from: data)
+                let finalDate = assetDate ?? exifMetadata.date
+                let finalLocation = assetLocation ?? exifMetadata.location
+
                 DispatchQueue.main.async {
                     let imageSource = ImageSourceData(
                         image: image,
+                        originalData: data,
                         format: format
                     )
-                    self?.imagePickerResultRelay.accept((imageSource, nil, nil, .library))
+                    self?.imagePickerResultRelay.accept((imageSource, finalLocation, finalDate, .library))
                 }
             } catch {
                 self?.loadImageFallback(from: itemProvider)

--- a/Sahara/Feature/CardInfo/MediaSelectionViewController.swift
+++ b/Sahara/Feature/CardInfo/MediaSelectionViewController.swift
@@ -129,11 +129,13 @@ final class MediaSelectionViewController: UIViewController {
                     ))
                 }
                 #else
-                actionItems.append(.action(
-                    icon: "photo.on.rectangle",
-                    title: NSLocalizedString("media_selection.library", comment: ""),
-                    type: .library
-                ))
+                if status != .authorized {
+                    actionItems.append(.action(
+                        icon: "photo.on.rectangle",
+                        title: NSLocalizedString("media_selection.library", comment: ""),
+                        type: .library
+                    ))
+                }
                 #endif
 
                 sections.append(SectionModel(model: "actions", items: actionItems))

--- a/Sahara/Feature/CardInfo/MediaSelectionViewController.swift
+++ b/Sahara/Feature/CardInfo/MediaSelectionViewController.swift
@@ -109,6 +109,7 @@ final class MediaSelectionViewController: UIViewController {
                 let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
                 var actionItems: [MediaCollectionItem] = []
 
+                #if !targetEnvironment(macCatalyst)
                 if status == .authorized {
                     actionItems.append(.action(
                         icon: "camera.fill",
@@ -127,6 +128,13 @@ final class MediaSelectionViewController: UIViewController {
                         type: .library
                     ))
                 }
+                #else
+                actionItems.append(.action(
+                    icon: "photo.on.rectangle",
+                    title: NSLocalizedString("media_selection.library", comment: ""),
+                    type: .library
+                ))
+                #endif
 
                 sections.append(SectionModel(model: "actions", items: actionItems))
 
@@ -154,11 +162,13 @@ final class MediaSelectionViewController: UIViewController {
             }
             .disposed(by: disposeBag)
 
+        #if !targetEnvironment(macCatalyst)
         output.showCamera
             .drive(with: self) { owner, _ in
                 owner.presentCamera()
             }
             .disposed(by: disposeBag)
+        #endif
 
         output.showPHPicker
             .drive(with: self) { owner, _ in
@@ -178,6 +188,7 @@ final class MediaSelectionViewController: UIViewController {
             }
             .disposed(by: disposeBag)
 
+        #if !targetEnvironment(macCatalyst)
         output.requestCameraPermission
             .drive(with: self) { owner, _ in
                 PermissionManager.shared.requestPermission(for: .camera, from: owner) { [weak owner] status in
@@ -190,6 +201,7 @@ final class MediaSelectionViewController: UIViewController {
                 }
             }
             .disposed(by: disposeBag)
+        #endif
 
         output.requestPhotoPermission
             .drive(with: self) { owner, _ in
@@ -216,6 +228,7 @@ final class MediaSelectionViewController: UIViewController {
             .disposed(by: disposeBag)
     }
 
+    #if !targetEnvironment(macCatalyst)
     private func presentCamera() {
         guard UIImagePickerController.isSourceTypeAvailable(.camera) else { return }
 
@@ -224,6 +237,7 @@ final class MediaSelectionViewController: UIViewController {
         picker.delegate = self
         present(picker, animated: true)
     }
+    #endif
 
     private func presentPHPicker() {
         var configuration = PHPickerConfiguration()

--- a/Sahara/Feature/CardInfo/MediaSelectionViewModel.swift
+++ b/Sahara/Feature/CardInfo/MediaSelectionViewModel.swift
@@ -56,6 +56,13 @@ final class MediaSelectionViewModel: BaseViewModelProtocol {
 
         input.viewWillAppear
             .bind(with: self) { owner, _ in
+                #if targetEnvironment(macCatalyst)
+                let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
+                if status == .notDetermined {
+                    requestPhotoPermissionRelay.accept(())
+                    return
+                }
+                #endif
                 owner.fetchPhotos(relay: photosRelay)
             }
             .disposed(by: disposeBag)
@@ -79,6 +86,17 @@ final class MediaSelectionViewModel: BaseViewModelProtocol {
 
         input.libraryButtonTapped
             .bind(with: self) { owner, _ in
+                #if targetEnvironment(macCatalyst)
+                let status = PermissionManager.shared.checkPermission(for: .photoLibrary)
+                switch status {
+                case .authorized:
+                    showPHPickerRelay.accept(())
+                case .notDetermined:
+                    requestPhotoPermissionRelay.accept(())
+                case .denied, .limited:
+                    showPHPickerRelay.accept(())
+                }
+                #else
                 let status = PermissionManager.shared.checkPermission(for: .photoLibrary)
 
                 switch status {
@@ -91,6 +109,7 @@ final class MediaSelectionViewModel: BaseViewModelProtocol {
                 case .notDetermined:
                     requestPhotoPermissionRelay.accept(())
                 }
+                #endif
             }
             .disposed(by: disposeBag)
 

--- a/Sahara/Feature/CardInfo/MediaSelectionViewModel.swift
+++ b/Sahara/Feature/CardInfo/MediaSelectionViewModel.swift
@@ -56,14 +56,10 @@ final class MediaSelectionViewModel: BaseViewModelProtocol {
 
         input.viewWillAppear
             .bind(with: self) { owner, _ in
-                #if targetEnvironment(macCatalyst)
-                let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
-                if status == .notDetermined {
-                    requestPhotoPermissionRelay.accept(())
-                    return
-                }
-                #endif
-                owner.fetchPhotos(relay: photosRelay)
+                owner.handleInitialPhotoLoad(
+                    photosRelay: photosRelay,
+                    requestPhotoPermissionRelay: requestPhotoPermissionRelay
+                )
             }
             .disposed(by: disposeBag)
 
@@ -86,30 +82,12 @@ final class MediaSelectionViewModel: BaseViewModelProtocol {
 
         input.libraryButtonTapped
             .bind(with: self) { owner, _ in
-                #if targetEnvironment(macCatalyst)
-                let status = PermissionManager.shared.checkPermission(for: .photoLibrary)
-                switch status {
-                case .authorized:
-                    showPHPickerRelay.accept(())
-                case .notDetermined:
-                    requestPhotoPermissionRelay.accept(())
-                case .denied, .limited:
-                    showPHPickerRelay.accept(())
-                }
-                #else
-                let status = PermissionManager.shared.checkPermission(for: .photoLibrary)
-
-                switch status {
-                case .authorized:
-                    showPHPickerRelay.accept(())
-                case .limited:
-                    showLimitedLibraryPickerRelay.accept(())
-                case .denied:
-                    showPhotoPermissionAlertRelay.accept(())
-                case .notDetermined:
-                    requestPhotoPermissionRelay.accept(())
-                }
-                #endif
+                owner.handleLibraryButtonTapped(
+                    showPHPickerRelay: showPHPickerRelay,
+                    showPhotoPermissionAlertRelay: showPhotoPermissionAlertRelay,
+                    requestPhotoPermissionRelay: requestPhotoPermissionRelay,
+                    showLimitedLibraryPickerRelay: showLimitedLibraryPickerRelay
+                )
             }
             .disposed(by: disposeBag)
 
@@ -148,6 +126,50 @@ final class MediaSelectionViewModel: BaseViewModelProtocol {
             requestCameraPermission: requestCameraPermissionRelay.asDriver(onErrorJustReturn: ()),
             showLimitedLibraryPicker: showLimitedLibraryPickerRelay.asDriver(onErrorJustReturn: ())
         )
+    }
+
+    private func handleInitialPhotoLoad(
+        photosRelay: BehaviorRelay<[PHAsset]>,
+        requestPhotoPermissionRelay: PublishRelay<Void>
+    ) {
+        #if targetEnvironment(macCatalyst)
+        let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
+        if status == .notDetermined {
+            requestPhotoPermissionRelay.accept(())
+            return
+        }
+        #endif
+        fetchPhotos(relay: photosRelay)
+    }
+
+    private func handleLibraryButtonTapped(
+        showPHPickerRelay: PublishRelay<Void>,
+        showPhotoPermissionAlertRelay: PublishRelay<Void>,
+        requestPhotoPermissionRelay: PublishRelay<Void>,
+        showLimitedLibraryPickerRelay: PublishRelay<Void>
+    ) {
+        let status = PermissionManager.shared.checkPermission(for: .photoLibrary)
+        #if targetEnvironment(macCatalyst)
+        switch status {
+        case .authorized:
+            showPHPickerRelay.accept(())
+        case .notDetermined:
+            requestPhotoPermissionRelay.accept(())
+        case .denied, .limited:
+            showPHPickerRelay.accept(())
+        }
+        #else
+        switch status {
+        case .authorized:
+            showPHPickerRelay.accept(())
+        case .limited:
+            showLimitedLibraryPickerRelay.accept(())
+        case .denied:
+            showPhotoPermissionAlertRelay.accept(())
+        case .notDetermined:
+            requestPhotoPermissionRelay.accept(())
+        }
+        #endif
     }
 
     private func fetchPhotos(relay: BehaviorRelay<[PHAsset]>) {

--- a/Sahara/Feature/Settings/SettingsViewController.swift
+++ b/Sahara/Feature/Settings/SettingsViewController.swift
@@ -304,12 +304,17 @@ final class SettingsViewController: UIViewController {
     }
 
     private func presentShareSheet(for url: URL) {
+        #if targetEnvironment(macCatalyst)
+        let picker = UIDocumentPickerViewController(forExporting: [url])
+        present(picker, animated: true)
+        #else
         let activityVC = UIActivityViewController(activityItems: [url], applicationActivities: nil)
         if let popover = activityVC.popoverPresentationController {
             popover.sourceView = view
             popover.sourceRect = CGRect(x: view.bounds.midX, y: view.bounds.midY, width: 0, height: 0)
         }
         present(activityVC, animated: true)
+        #endif
     }
 
     private func showBackupError(title: String, error: Error) {

--- a/Sahara/Feature/Settings/SettingsViewController.swift
+++ b/Sahara/Feature/Settings/SettingsViewController.swift
@@ -175,8 +175,11 @@ final class SettingsViewController: UIViewController {
     }
 
     private func presentMailComposer(to email: String) {
+        #if targetEnvironment(macCatalyst)
+        openMailtoURL(to: email, subject: NSLocalizedString("settings.inquiry_subject", comment: ""), body: generateEmailBody())
+        #else
         guard MFMailComposeViewController.canSendMail() else {
-            showMailError()
+            copyEmailFallback(email: email)
             return
         }
 
@@ -187,12 +190,55 @@ final class SettingsViewController: UIViewController {
         mailComposer.setMessageBody(generateEmailBody(), isHTML: false)
 
         present(mailComposer, animated: true)
+        #endif
+    }
+
+    private func openMailtoURL(to email: String, subject: String, body: String) {
+        var components = URLComponents()
+        components.scheme = "mailto"
+        components.path = email
+        components.queryItems = [
+            URLQueryItem(name: "subject", value: subject),
+            URLQueryItem(name: "body", value: body)
+        ]
+
+        guard let url = components.url else {
+            copyEmailFallback(email: email)
+            return
+        }
+
+        UIApplication.shared.open(url) { [weak self] success in
+            if !success {
+                self?.copyEmailFallback(email: email)
+            }
+        }
+    }
+
+    private func copyEmailFallback(email: String) {
+        UIPasteboard.general.string = email
+        let alert = UIAlertController(
+            title: NSLocalizedString("settings.mail_error_title", comment: ""),
+            message: NSLocalizedString("realm_error.email_copied", comment: ""),
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: NSLocalizedString("common.ok", comment: ""), style: .default))
+        present(alert, animated: true)
     }
 
     private func generateEmailBody() -> String {
         let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
-        let iosVersion = UIDevice.current.systemVersion
-        let deviceModel = getDeviceModel()
+        let osVersionLabel: String
+        let osVersion: String
+        let deviceModel = DeviceInfo.displayName
+
+        #if targetEnvironment(macCatalyst)
+        osVersionLabel = NSLocalizedString("settings.macos_version", comment: "")
+        let version = ProcessInfo.processInfo.operatingSystemVersion
+        osVersion = "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
+        #else
+        osVersionLabel = NSLocalizedString("settings.ios_version", comment: "")
+        osVersion = UIDevice.current.systemVersion
+        #endif
 
         return """
         \(NSLocalizedString("settings.inquiry_message_placeholder", comment: ""))
@@ -200,47 +246,9 @@ final class SettingsViewController: UIViewController {
         ---
         \(NSLocalizedString("settings.device_info_title", comment: ""))
         - \(NSLocalizedString("settings.app_version", comment: "")): \(appVersion)
-        - \(NSLocalizedString("settings.ios_version", comment: "")): \(iosVersion)
+        - \(osVersionLabel): \(osVersion)
         - \(NSLocalizedString("settings.device_model", comment: "")): \(deviceModel)
         """
-    }
-
-    private func getDeviceModel() -> String {
-        let code = DeviceInfo.modelIdentifier
-
-        let deviceModelMap: [String: String] = [
-            "iPhone14,2": "iPhone 13 Pro",
-            "iPhone14,3": "iPhone 13 Pro Max",
-            "iPhone14,4": "iPhone 13 mini",
-            "iPhone14,5": "iPhone 13",
-            "iPhone14,6": "iPhone SE (3rd generation)",
-            "iPhone14,7": "iPhone 14",
-            "iPhone14,8": "iPhone 14 Plus",
-            "iPhone15,2": "iPhone 14 Pro",
-            "iPhone15,3": "iPhone 14 Pro Max",
-            "iPhone15,4": "iPhone 15",
-            "iPhone15,5": "iPhone 15 Plus",
-            "iPhone16,1": "iPhone 15 Pro",
-            "iPhone16,2": "iPhone 15 Pro Max",
-            "iPhone17,1": "iPhone 16 Pro",
-            "iPhone17,2": "iPhone 16 Pro Max",
-            "iPhone17,3": "iPhone 16",
-            "iPhone17,4": "iPhone 16 Plus",
-            "arm64": "Simulator",
-            "x86_64": "Simulator"
-        ]
-
-        return deviceModelMap[code] ?? code
-    }
-
-    private func showMailError() {
-        let alert = UIAlertController(
-            title: NSLocalizedString("settings.mail_error_title", comment: ""),
-            message: NSLocalizedString("settings.mail_error_message", comment: ""),
-            preferredStyle: .alert
-        )
-        alert.addAction(UIAlertAction(title: NSLocalizedString("common.ok", comment: ""), style: .default))
-        present(alert, animated: true)
     }
 
     private func handleToggleChanged(for item: SettingsMenuItem, isOn: Bool) {

--- a/Sahara/Feature/Stats/PieChartView.swift
+++ b/Sahara/Feature/Stats/PieChartView.swift
@@ -111,7 +111,7 @@ final class PieChartView: UIView {
             textLayer.fontSize = 12
             textLayer.foregroundColor = UIColor.token(.textPrimary).cgColor
             textLayer.alignmentMode = .center
-            textLayer.contentsScale = UIScreen.main.scale
+            textLayer.contentsScale = window?.screen.scale ?? 2.0
 
             let textSize = (labelText as NSString).size(withAttributes: [.font: FontSystem.galmuriMono(size: 12)])
             textLayer.frame = CGRect(

--- a/Sahara/Info.plist
+++ b/Sahara/Info.plist
@@ -46,7 +46,7 @@
 	<key>NSUserNotificationsUsageDescription</key>
 	<string></string>
 	<key>LSSupportsOpeningDocumentsInPlace</key>
-	<false/>
+	<true/>
 	<key>UTExportedTypeDeclarations</key>
 	<array>
 		<dict>
@@ -74,7 +74,7 @@
 			<key>CFBundleTypeName</key>
 			<string>Sahara Backup</string>
 			<key>CFBundleTypeRole</key>
-			<string>Owner</string>
+			<string>Editor</string>
 			<key>LSHandlerRank</key>
 			<string>Owner</string>
 			<key>LSItemContentTypes</key>

--- a/Sahara/Resources/en.lproj/Localizable.strings
+++ b/Sahara/Resources/en.lproj/Localizable.strings
@@ -91,6 +91,10 @@
 "media_selection.photo_permission_message" = "Please allow photo library access in Settings";
 "media_selection.go_to_settings" = "Go to Settings";
 
+/* Camera */
+"camera.unavailable_title" = "Camera Unavailable";
+"camera.unavailable_message" = "Camera is not available on this device.";
+
 /* Media Editor */
 "media_editor.title" = "Photo Editor";
 "media_editor.done" = "Done";

--- a/Sahara/Resources/en.lproj/Localizable.strings
+++ b/Sahara/Resources/en.lproj/Localizable.strings
@@ -197,6 +197,7 @@
 "settings.device_info_title" = "Device Information";
 "settings.app_version" = "App Version";
 "settings.ios_version" = "iOS Version";
+"settings.macos_version" = "macOS Version";
 "settings.device_model" = "Device Model";
 "settings.section_data" = "Data Management";
 "settings.export_photos" = "Export Photos";

--- a/Sahara/Resources/ja.lproj/Localizable.strings
+++ b/Sahara/Resources/ja.lproj/Localizable.strings
@@ -91,6 +91,10 @@
 "media_selection.photo_permission_message" = "設定でフォトライブラリアクセス権限を許可してください";
 "media_selection.go_to_settings" = "設定に移動";
 
+/* Camera */
+"camera.unavailable_title" = "カメラを使用できません";
+"camera.unavailable_message" = "このデバイスではカメラを使用できません。";
+
 /* Media Editor */
 "media_editor.title" = "写真編集";
 "media_editor.done" = "完了";

--- a/Sahara/Resources/ja.lproj/Localizable.strings
+++ b/Sahara/Resources/ja.lproj/Localizable.strings
@@ -197,6 +197,7 @@
 "settings.device_info_title" = "デバイス情報";
 "settings.app_version" = "アプリバージョン";
 "settings.ios_version" = "iOSバージョン";
+"settings.macos_version" = "macOSバージョン";
 "settings.device_model" = "デバイスモデル";
 "settings.section_data" = "データ管理";
 "settings.export_photos" = "写真をエクスポート";

--- a/Sahara/Resources/ko.lproj/Localizable.strings
+++ b/Sahara/Resources/ko.lproj/Localizable.strings
@@ -197,6 +197,7 @@
 "settings.device_info_title" = "기기 정보";
 "settings.app_version" = "앱 버전";
 "settings.ios_version" = "iOS 버전";
+"settings.macos_version" = "macOS 버전";
 "settings.device_model" = "기기 모델";
 "settings.section_data" = "데이터 관리";
 "settings.export_photos" = "사진 내보내기";

--- a/Sahara/Resources/ko.lproj/Localizable.strings
+++ b/Sahara/Resources/ko.lproj/Localizable.strings
@@ -91,6 +91,10 @@
 "media_selection.photo_permission_message" = "사진을 선택하려면 설정에서 사진 라이브러리 권한을 허용해요";
 "media_selection.go_to_settings" = "설정으로 이동";
 
+/* Camera */
+"camera.unavailable_title" = "카메라를 사용할 수 없어요";
+"camera.unavailable_message" = "이 기기에서는 카메라를 사용할 수 없습니다.";
+
 /* Media Editor */
 "media_editor.title" = "사진 편집";
 "media_editor.done" = "완료";

--- a/Sahara/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sahara/Resources/zh-Hans.lproj/Localizable.strings
@@ -190,6 +190,7 @@
 "settings.version_info" = "版本信息";
 "settings.mail_error_title" = "无法发送邮件";
 "settings.mail_error_message" = "邮件应用不可用";
+"settings.macos_version" = "macOS版本";
 "settings.notification_denied_title" = "需要通知设置";
 "settings.notification_denied_message" = "请在设置中启用通知";
 "settings.section_data" = "数据管理";

--- a/Sahara/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sahara/Resources/zh-Hans.lproj/Localizable.strings
@@ -91,6 +91,10 @@
 "media_selection.photo_permission_message" = "请在设置中允许照片库权限";
 "media_selection.go_to_settings" = "前往设置";
 
+/* Camera */
+"camera.unavailable_title" = "无法使用相机";
+"camera.unavailable_message" = "此设备不支持相机功能。";
+
 /* Media Editor */
 "media_editor.title" = "照片编辑";
 "media_editor.done" = "完成";

--- a/Sahara/Sahara.entitlements
+++ b/Sahara/Sahara.entitlements
@@ -4,6 +4,8 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.security.device.camera</key>
+	<true/>
 	<key>com.apple.security.personal-information.photos-library</key>
 	<true/>
 	<key>keychain-access-groups</key>

--- a/Sahara/Sahara.entitlements
+++ b/Sahara/Sahara.entitlements
@@ -4,5 +4,11 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.security.personal-information.photos-library</key>
+	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)com.miya.Sahara</string>
+	</array>
 </dict>
 </plist>

--- a/Sahara/SceneDelegate.swift
+++ b/Sahara/SceneDelegate.swift
@@ -16,6 +16,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
 
         guard let scene = (scene as? UIWindowScene) else { return }
+
+        #if targetEnvironment(macCatalyst)
+        scene.sizeRestrictions?.minimumSize = CGSize(width: 600, height: 500)
+        scene.sizeRestrictions?.maximumSize = CGSize(width: 1200, height: 900)
+        #endif
+
         window = UIWindow(windowScene: scene)
 
         if RealmManager.validateRealm() != nil {

--- a/Sahara/SceneDelegate.swift
+++ b/Sahara/SceneDelegate.swift
@@ -66,39 +66,86 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     private func presentRealmErrorMail(on viewController: UIViewController) {
+        let email = "gageum0@gmail.com"
+        let subject = NSLocalizedString("realm_error.mail_subject", comment: "")
+        let body = generateRealmErrorMailBody()
+
+        #if targetEnvironment(macCatalyst)
+        openMailtoURL(to: email, subject: subject, body: body, fallbackPresenter: viewController)
+        #else
         guard MFMailComposeViewController.canSendMail() else {
-            UIPasteboard.general.string = "gageum0@gmail.com"
-            let fallback = UIAlertController(
-                title: NSLocalizedString("settings.mail_error_title", comment: ""),
-                message: NSLocalizedString("realm_error.email_copied", comment: ""),
-                preferredStyle: .alert
-            )
-            fallback.addAction(UIAlertAction(title: NSLocalizedString("common.ok", comment: ""), style: .default))
-            viewController.present(fallback, animated: true)
+            copyEmailFallback(email: email, presenter: viewController)
             return
         }
 
         let mailComposer = MFMailComposeViewController()
         mailComposer.mailComposeDelegate = self
-        mailComposer.setToRecipients(["gageum0@gmail.com"])
-        mailComposer.setSubject(NSLocalizedString("realm_error.mail_subject", comment: ""))
+        mailComposer.setToRecipients([email])
+        mailComposer.setSubject(subject)
+        mailComposer.setMessageBody(body, isHTML: false)
 
+        viewController.present(mailComposer, animated: true)
+        #endif
+    }
+
+    private func generateRealmErrorMailBody() -> String {
         let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
-        let iosVersion = UIDevice.current.systemVersion
-        let body = """
+        let osVersionLabel: String
+        let osVersion: String
+
+        #if targetEnvironment(macCatalyst)
+        osVersionLabel = NSLocalizedString("settings.macos_version", comment: "")
+        let version = ProcessInfo.processInfo.operatingSystemVersion
+        osVersion = "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
+        #else
+        osVersionLabel = NSLocalizedString("settings.ios_version", comment: "")
+        osVersion = UIDevice.current.systemVersion
+        #endif
+
+        return """
         \(NSLocalizedString("realm_error.mail_body", comment: ""))
 
         ---
         \(NSLocalizedString("settings.app_version", comment: "")): \(appVersion)
-        \(NSLocalizedString("settings.ios_version", comment: "")): \(iosVersion)
+        \(osVersionLabel): \(osVersion)
         """
-        mailComposer.setMessageBody(body, isHTML: false)
+    }
 
-        viewController.present(mailComposer, animated: true)
+    private func openMailtoURL(to email: String, subject: String, body: String, fallbackPresenter: UIViewController) {
+        var components = URLComponents()
+        components.scheme = "mailto"
+        components.path = email
+        components.queryItems = [
+            URLQueryItem(name: "subject", value: subject),
+            URLQueryItem(name: "body", value: body)
+        ]
+
+        guard let url = components.url else {
+            copyEmailFallback(email: email, presenter: fallbackPresenter)
+            return
+        }
+
+        UIApplication.shared.open(url) { [weak self] success in
+            if !success {
+                self?.copyEmailFallback(email: email, presenter: fallbackPresenter)
+            }
+        }
+    }
+
+    private func copyEmailFallback(email: String, presenter: UIViewController) {
+        UIPasteboard.general.string = email
+        let alert = UIAlertController(
+            title: NSLocalizedString("settings.mail_error_title", comment: ""),
+            message: NSLocalizedString("realm_error.email_copied", comment: ""),
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: NSLocalizedString("common.ok", comment: ""), style: .default))
+        presenter.present(alert, animated: true)
     }
 
     private func configureWindowSize(for scene: UIWindowScene) {
         #if targetEnvironment(macCatalyst)
+        scene.title = "Sahara"
         scene.sizeRestrictions?.minimumSize = CGSize(width: 600, height: 500)
         scene.sizeRestrictions?.maximumSize = CGSize(width: 1200, height: 900)
         #endif

--- a/Sahara/SceneDelegate.swift
+++ b/Sahara/SceneDelegate.swift
@@ -17,10 +17,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         guard let scene = (scene as? UIWindowScene) else { return }
 
-        #if targetEnvironment(macCatalyst)
-        scene.sizeRestrictions?.minimumSize = CGSize(width: 600, height: 500)
-        scene.sizeRestrictions?.maximumSize = CGSize(width: 1200, height: 900)
-        #endif
+        configureWindowSize(for: scene)
 
         window = UIWindow(windowScene: scene)
 
@@ -98,6 +95,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         mailComposer.setMessageBody(body, isHTML: false)
 
         viewController.present(mailComposer, animated: true)
+    }
+
+    private func configureWindowSize(for scene: UIWindowScene) {
+        #if targetEnvironment(macCatalyst)
+        scene.sizeRestrictions?.minimumSize = CGSize(width: 600, height: 500)
+        scene.sizeRestrictions?.maximumSize = CGSize(width: 1200, height: 900)
+        #endif
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/SaharaTests/EXIFMetadataExtractorTests.swift
+++ b/SaharaTests/EXIFMetadataExtractorTests.swift
@@ -1,0 +1,203 @@
+//
+//  EXIFMetadataExtractorTests.swift
+//  SaharaTests
+//
+
+import CoreLocation
+import ImageIO
+import XCTest
+@testable import Sahara
+
+final class EXIFMetadataExtractorTests: XCTestCase {
+
+    private func createJPEGDataWithEXIF(
+        dateTimeOriginal: String? = nil,
+        tiffDateTime: String? = nil,
+        latitude: Double? = nil,
+        latitudeRef: String? = nil,
+        longitude: Double? = nil,
+        longitudeRef: String? = nil
+    ) -> Data? {
+        let size = CGSize(width: 10, height: 10)
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1.0
+        let renderer = UIGraphicsImageRenderer(size: size, format: format)
+        let image = renderer.image { context in
+            UIColor.white.setFill()
+            context.fill(CGRect(origin: .zero, size: size))
+        }
+
+        guard let cgImage = image.cgImage else { return nil }
+
+        let mutableData = CFDataCreateMutable(nil, 0)!
+        guard let destination = CGImageDestinationCreateWithData(
+            mutableData,
+            "public.jpeg" as CFString,
+            1,
+            nil
+        ) else { return nil }
+
+        var metadata = [String: Any]()
+
+        if dateTimeOriginal != nil || tiffDateTime != nil {
+            if let dateTimeOriginal = dateTimeOriginal {
+                var exifDict = [String: Any]()
+                exifDict[kCGImagePropertyExifDateTimeOriginal as String] = dateTimeOriginal
+                metadata[kCGImagePropertyExifDictionary as String] = exifDict
+            }
+            if let tiffDateTime = tiffDateTime {
+                var tiffDict = [String: Any]()
+                tiffDict[kCGImagePropertyTIFFDateTime as String] = tiffDateTime
+                metadata[kCGImagePropertyTIFFDictionary as String] = tiffDict
+            }
+        }
+
+        if let latitude = latitude, let longitude = longitude {
+            var gpsDict = [String: Any]()
+            gpsDict[kCGImagePropertyGPSLatitude as String] = latitude
+            gpsDict[kCGImagePropertyGPSLongitude as String] = longitude
+            if let latRef = latitudeRef {
+                gpsDict[kCGImagePropertyGPSLatitudeRef as String] = latRef
+            }
+            if let lonRef = longitudeRef {
+                gpsDict[kCGImagePropertyGPSLongitudeRef as String] = lonRef
+            }
+            metadata[kCGImagePropertyGPSDictionary as String] = gpsDict
+        }
+
+        CGImageDestinationAddImage(
+            destination,
+            cgImage,
+            metadata as CFDictionary
+        )
+        guard CGImageDestinationFinalize(destination) else { return nil }
+        return mutableData as Data
+    }
+
+    func test_extractFromData_parsesDateTimeOriginal() {
+        guard let data = createJPEGDataWithEXIF(dateTimeOriginal: "2025:06:15 14:30:00") else {
+            XCTFail("Failed to create test JPEG data")
+            return
+        }
+
+        let result = EXIFMetadataExtractor.extract(from: data)
+
+        XCTAssertNotNil(result.date)
+        let calendar = Calendar.current
+        let components = calendar.dateComponents([.year, .month, .day, .hour, .minute], from: result.date!)
+        XCTAssertEqual(components.year, 2025)
+        XCTAssertEqual(components.month, 6)
+        XCTAssertEqual(components.day, 15)
+        XCTAssertEqual(components.hour, 14)
+        XCTAssertEqual(components.minute, 30)
+    }
+
+    func test_extractFromData_fallsBackToTIFFDateTime() {
+        guard let data = createJPEGDataWithEXIF(tiffDateTime: "2024:12:25 09:00:00") else {
+            XCTFail("Failed to create test JPEG data")
+            return
+        }
+
+        let result = EXIFMetadataExtractor.extract(from: data)
+
+        XCTAssertNotNil(result.date)
+        let calendar = Calendar.current
+        let components = calendar.dateComponents([.year, .month, .day], from: result.date!)
+        XCTAssertEqual(components.year, 2024)
+        XCTAssertEqual(components.month, 12)
+        XCTAssertEqual(components.day, 25)
+    }
+
+    func test_extractFromData_parsesGPSNorthEast() {
+        guard let data = createJPEGDataWithEXIF(
+            latitude: 37.5665,
+            latitudeRef: "N",
+            longitude: 126.9780,
+            longitudeRef: "E"
+        ) else {
+            XCTFail("Failed to create test JPEG data")
+            return
+        }
+
+        let result = EXIFMetadataExtractor.extract(from: data)
+
+        XCTAssertNotNil(result.location)
+        XCTAssertEqual(result.location!.coordinate.latitude, 37.5665, accuracy: 0.001)
+        XCTAssertEqual(result.location!.coordinate.longitude, 126.9780, accuracy: 0.001)
+    }
+
+    func test_extractFromData_parsesGPSSouthWest() {
+        guard let data = createJPEGDataWithEXIF(
+            latitude: 33.8688,
+            latitudeRef: "S",
+            longitude: 151.2093,
+            longitudeRef: "W"
+        ) else {
+            XCTFail("Failed to create test JPEG data")
+            return
+        }
+
+        let result = EXIFMetadataExtractor.extract(from: data)
+
+        XCTAssertNotNil(result.location)
+        XCTAssertEqual(result.location!.coordinate.latitude, -33.8688, accuracy: 0.001)
+        XCTAssertEqual(result.location!.coordinate.longitude, -151.2093, accuracy: 0.001)
+    }
+
+    func test_extractFromData_returnsNilForImageWithoutEXIF() {
+        let size = CGSize(width: 10, height: 10)
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1.0
+        let renderer = UIGraphicsImageRenderer(size: size, format: format)
+        let image = renderer.image { context in
+            UIColor.white.setFill()
+            context.fill(CGRect(origin: .zero, size: size))
+        }
+        guard let data = image.jpegData(compressionQuality: 0.5) else {
+            XCTFail("Failed to create JPEG data")
+            return
+        }
+
+        let result = EXIFMetadataExtractor.extract(from: data)
+
+        XCTAssertNil(result.date)
+        XCTAssertNil(result.location)
+    }
+
+    func test_extractFromMetadata_parsesDateTimeOriginal() {
+        let metadata: [String: Any] = [
+            kCGImagePropertyExifDictionary as String: [
+                kCGImagePropertyExifDateTimeOriginal as String: "2025:03:10 12:00:00"
+            ]
+        ]
+
+        let result = EXIFMetadataExtractor.extract(from: metadata)
+
+        XCTAssertNotNil(result.date)
+        let calendar = Calendar.current
+        let components = calendar.dateComponents([.year, .month, .day], from: result.date!)
+        XCTAssertEqual(components.year, 2025)
+        XCTAssertEqual(components.month, 3)
+        XCTAssertEqual(components.day, 10)
+    }
+
+    func test_extractFromMetadata_locationIsAlwaysNil() {
+        let metadata: [String: Any] = [
+            kCGImagePropertyGPSDictionary as String: [
+                kCGImagePropertyGPSLatitude as String: 37.0,
+                kCGImagePropertyGPSLongitude as String: 127.0
+            ]
+        ]
+
+        let result = EXIFMetadataExtractor.extract(from: metadata)
+
+        XCTAssertNil(result.location)
+    }
+
+    func test_extractFromMetadata_returnsNilForEmptyDict() {
+        let result = EXIFMetadataExtractor.extract(from: [:])
+
+        XCTAssertNil(result.date)
+        XCTAssertNil(result.location)
+    }
+}


### PR DESCRIPTION
Closes #47

## 변경 내용

**추가**
- Mac Catalyst 빌드 지원 활성화 및 entitlements 설정
- 윈도우 크기 제한 (최소/최대) 설정으로 Mac에서 적절한 앱 크기 유지
- EXIF 메타데이터 추출기 — PHPicker/카메라 촬영 사진에서 날짜·GPS 정보 파싱
- Mac Catalyst에서 AVFoundation 기반 카메라 캡처 (UIImagePickerController 대체)
- 네이티브 파일 저장 다이얼로그로 사진 내보내기 (Mac Catalyst)
- 카메라 미지원 환경에서 알림 표시
- DeviceInfo.displayName으로 Mac 모델명 표시 및 mailto: 링크 지원
- 4개 언어 로컬라이제이션 (카메라 관련 문구)
- EXIF 메타데이터 추출 테스트

**수정**
- UIScreen.main을 window 기반 화면 접근으로 교체 (deprecated API 제거)
- 그래디언트/도트 패턴이 Mac Catalyst 풀스크린 전환 시 크기 미갱신되던 문제 수정
- 카메라/미디어 선택 흐름을 플랫폼별로 분기 처리
- 공유 팝오버에 sourceRect 추가 (iPad/Mac 크래시 방지)
- 플랫폼별 코드를 전용 메서드로 분리하여 가독성 개선

## 결정 근거

- **AVFoundation 카메라** — Mac Catalyst에서 UIImagePickerController.camera를 지원하지 않아 AVCaptureSession 기반 직접 구현
- **EXIF 추출** — PHPicker가 UIImage만 반환하므로 CGImageSource로 원본 메타데이터를 별도 추출하여 날짜/위치 정보 보존
- **window 기반 화면 접근** — UIScreen.main이 iOS 16에서 deprecated되어 UIWindowScene 기반으로 전환
- **sourceRect 추가** — iPad/Mac에서 UIActivityViewController를 popover로 표시할 때 sourceRect 누락 시 크래시 발생