### PR TITLE
Fix iPhone layout regression from iPad adaptation

### DIFF
--- a/Sahara/Feature/CardDetail/CardDetailViewController.swift
+++ b/Sahara/Feature/CardDetail/CardDetailViewController.swift
@@ -37,7 +37,8 @@ final class CardDetailViewController: UIViewController {
     }()
 
     private lazy var photoCardView: PhotoCardView = {
-        let cardWidth = min(view.bounds.width - 64, 500)
+        let availableWidth = view.bounds.width - 64
+        let cardWidth = UIDevice.current.userInterfaceIdiom == .phone ? availableWidth : min(availableWidth, 500)
         return PhotoCardView(cardWidth: cardWidth)
     }()
 
@@ -157,9 +158,13 @@ final class CardDetailViewController: UIViewController {
 
         photoCardView.snp.makeConstraints { make in
             make.top.equalToSuperview().offset(32)
-            make.centerX.equalToSuperview()
-            make.width.lessThanOrEqualTo(500)
-            make.horizontalEdges.equalToSuperview().inset(32).priority(.medium)
+            if UIDevice.current.userInterfaceIdiom == .phone {
+                make.horizontalEdges.equalToSuperview().inset(32)
+            } else {
+                make.centerX.equalToSuperview()
+                make.width.lessThanOrEqualTo(500)
+                make.horizontalEdges.equalToSuperview().inset(32).priority(.medium)
+            }
         }
 
         buttonContainerView.snp.makeConstraints { make in

--- a/Sahara/Feature/CardInfo/CardInfoViewController.swift
+++ b/Sahara/Feature/CardInfo/CardInfoViewController.swift
@@ -125,10 +125,14 @@ final class CardInfoViewController: UIViewController {
 
         contentView.snp.makeConstraints { make in
             make.top.equalTo(customNavigationBar.snp.bottom)
-            make.centerX.equalToSuperview()
-            make.width.lessThanOrEqualTo(600)
-            make.horizontalEdges.equalTo(view.safeAreaLayoutGuide).priority(.medium)
             make.bottom.equalTo(view.safeAreaLayoutGuide)
+            if UIDevice.current.userInterfaceIdiom == .phone {
+                make.horizontalEdges.equalTo(view.safeAreaLayoutGuide)
+            } else {
+                make.centerX.equalToSuperview()
+                make.width.lessThanOrEqualTo(600)
+                make.horizontalEdges.equalTo(view.safeAreaLayoutGuide).priority(.medium)
+            }
         }
 
         contentView.scrollView.snp.remakeConstraints { make in


### PR DESCRIPTION
Closes #51

## 변경 내용

**수정**
- iPhone에서 사진 카드와 편집 화면의 레이아웃 제약조건을 복원
- iPad/Mac에서는 기존 maxWidth 제약조건을 유지하고, iPhone에서만 검증된 고정 제약조건을 적용

## 결정 근거

- **디바이스 분기** — iPad PR의 medium priority 제약조건이 iPhone에서 cornerRadius 소실, 텍스트 잘림, 편집 버튼 탭 불가 등의 회귀를 유발하여, `userInterfaceIdiom` 기반으로 플랫폼별 제약조건을 분리