### PR TITLE
Add home screen widget with random pool rotation

### DIFF
--- a/Sahara.xcodeproj/project.pbxproj
+++ b/Sahara.xcodeproj/project.pbxproj
@@ -22,6 +22,18 @@
 		03E2B5DC2E866F3C00A8C8DA /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 03E2B5DB2E866F3C00A8C8DA /* RxSwift */; };
 		03E2B5DF2E866F4B00A8C8DA /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 03E2B5DE2E866F4B00A8C8DA /* Kingfisher */; };
 		03F1A0032EC3D00100B4C003 /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 03F1A0022EC3D00100B4C002 /* ZIPFoundation */; };
+		11EAA4A28534A849B54F71B8 /* SaharaWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A08EFBD5AC7A29DB84BAB22 /* SaharaWidget.swift */; };
+		35809AA4E121A6056CB56712 /* AppGroupContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C9971CF5130426575EB86B8 /* AppGroupContainer.swift */; };
+		40509515DF5217AEC51F227B /* SaharaWidget.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 1DB96372ED38F2E168CE54D0 /* SaharaWidget.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		41F9CBFF45B2A7276A014737 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 7F687188F77FC625DD9732CC /* Localizable.strings */; };
+		48B972EDA01A0D7DFAC497C8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FAF3F6268F7FE8A9ADB1A7EB /* Assets.xcassets */; };
+		9716DC354EDCBBF970FC7B1C /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5784B26A0B503F279A42BC75 /* Foundation.framework */; };
+		AD85792DE201FA8468B3E41E /* OnThisDaySelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44A26D12CF118BD5052ABBF6 /* OnThisDaySelector.swift */; };
+		EA52C3608F29D4B30139A488 /* WidgetCardEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116F65DEB3596628C0C1D92 /* WidgetCardEntry.swift */; };
+		F6478EED89A88C5C9B8679BF /* SaharaWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FC5D9D4D4DD259374C87E64 /* SaharaWidgetBundle.swift */; };
+		FCDBDE9C8938DB07A5B50AF6 /* WidgetEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A0295F178A2885F15A30C0 /* WidgetEntryView.swift */; };
+		A1F0E7C3D8B24A9F10C3E002 /* Galmuri11-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A1F0E7C3D8B24A9F10C3F002 /* Galmuri11-Bold.ttf */; };
+		A1F0E7C3D8B24A9F10C3E003 /* Galmuri14.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A1F0E7C3D8B24A9F10C3F003 /* Galmuri14.ttf */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -31,6 +43,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 03E2B5B42E8664AB00A8C8DA;
 			remoteInfo = Sahara;
+		};
+		9F6C04DDB36FD24530F0AF49 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 03E2B5AD2E8664AB00A8C8DA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E45FD418C3D55D51C662192E;
+			remoteInfo = SaharaWidget;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -57,12 +76,41 @@
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		0CF3CF22A2FCCC42E0636E51 /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				40509515DF5217AEC51F227B /* SaharaWidget.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		034694692EA127BF0003065C /* SaharaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SaharaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		03E2B5B52E8664AB00A8C8DA /* Sahara.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Sahara.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		03E2B5CD2E8664E400A8C8DA /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
+		1116F65DEB3596628C0C1D92 /* WidgetCardEntry.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WidgetCardEntry.swift; path = Sahara/Common/Model/WidgetCardEntry.swift; sourceTree = SOURCE_ROOT; };
+		1DB96372ED38F2E168CE54D0 /* SaharaWidget.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = SaharaWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		2248A9DE1AE24A3DFBF50CFE /* zh-Hans */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		2FFA727C3FD2CBCD02C8459C /* ja */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
+		42B47BDB082DFD3FB45AC439 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4301DA729761C01C60469C92 /* SaharaWidget.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = SaharaWidget.entitlements; sourceTree = "<group>"; };
+		44A26D12CF118BD5052ABBF6 /* OnThisDaySelector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OnThisDaySelector.swift; path = Sahara/Common/Utility/OnThisDaySelector.swift; sourceTree = SOURCE_ROOT; };
+		47CD2822568FA817EC45BEE9 /* en */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		4C9971CF5130426575EB86B8 /* AppGroupContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AppGroupContainer.swift; path = Sahara/Common/Utility/AppGroupContainer.swift; sourceTree = SOURCE_ROOT; };
+		5784B26A0B503F279A42BC75 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		9A08EFBD5AC7A29DB84BAB22 /* SaharaWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SaharaWidget.swift; sourceTree = "<group>"; };
+		9FC5D9D4D4DD259374C87E64 /* SaharaWidgetBundle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SaharaWidgetBundle.swift; sourceTree = "<group>"; };
+		CE323ED067314EE13712B049 /* WidgetKit.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
+		D1A0295F178A2885F15A30C0 /* WidgetEntryView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WidgetEntryView.swift; sourceTree = "<group>"; };
+		DDAE112A04E74E8EB5EDDB78 /* ko */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
+		FAF3F6268F7FE8A9ADB1A7EB /* Assets.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		A1F0E7C3D8B24A9F10C3F002 /* Galmuri11-Bold.ttf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = "Galmuri11-Bold.ttf"; path = "Sahara/Resources/Fonts/Galmuri11-Bold.ttf"; sourceTree = SOURCE_ROOT; };
+		A1F0E7C3D8B24A9F10C3F003 /* Galmuri14.ttf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = Galmuri14.ttf; path = Sahara/Resources/Fonts/Galmuri14.ttf; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -118,12 +166,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		99971638BA62160923E272A2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9716DC354EDCBBF970FC7B1C /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
 		032681792E9D5D6C00D44CC4 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				0F70D77D94F96D5BE854F814 /* iOS */,
+				CE323ED067314EE13712B049 /* WidgetKit.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -136,6 +194,8 @@
 				0346946A2EA127BF0003065C /* SaharaTests */,
 				032681792E9D5D6C00D44CC4 /* Frameworks */,
 				03E2B5B62E8664AB00A8C8DA /* Products */,
+				673E3F5E08351D0A78BD3671 /* SaharaWidget */,
+				C1BA6AAC55D437A4B615D5FB /* Sahara */,
 			);
 			sourceTree = "<group>";
 		};
@@ -144,8 +204,51 @@
 			children = (
 				03E2B5B52E8664AB00A8C8DA /* Sahara.app */,
 				034694692EA127BF0003065C /* SaharaTests.xctest */,
+				1DB96372ED38F2E168CE54D0 /* SaharaWidget.appex */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		060E2F6095A14C26C94BEAA0 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				7F687188F77FC625DD9732CC /* Localizable.strings */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		0F70D77D94F96D5BE854F814 /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				5784B26A0B503F279A42BC75 /* Foundation.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		673E3F5E08351D0A78BD3671 /* SaharaWidget */ = {
+			isa = PBXGroup;
+			children = (
+				4301DA729761C01C60469C92 /* SaharaWidget.entitlements */,
+				42B47BDB082DFD3FB45AC439 /* Info.plist */,
+				FAF3F6268F7FE8A9ADB1A7EB /* Assets.xcassets */,
+				9FC5D9D4D4DD259374C87E64 /* SaharaWidgetBundle.swift */,
+				9A08EFBD5AC7A29DB84BAB22 /* SaharaWidget.swift */,
+				D1A0295F178A2885F15A30C0 /* WidgetEntryView.swift */,
+				060E2F6095A14C26C94BEAA0 /* Resources */,
+				4C9971CF5130426575EB86B8 /* AppGroupContainer.swift */,
+				1116F65DEB3596628C0C1D92 /* WidgetCardEntry.swift */,
+				44A26D12CF118BD5052ABBF6 /* OnThisDaySelector.swift */,
+				A1F0E7C3D8B24A9F10C3F002 /* Galmuri11-Bold.ttf */,
+				A1F0E7C3D8B24A9F10C3F003 /* Galmuri14.ttf */,
+			);
+			path = SaharaWidget;
+			sourceTree = "<group>";
+		};
+		C1BA6AAC55D437A4B615D5FB /* Sahara */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Sahara;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -185,10 +288,12 @@
 				03E2B5B32E8664AB00A8C8DA /* Resources */,
 				0397458C2E86DEDA00BDA511 /* Embed Frameworks */,
 				035A09452E90D48500221B3E /* ShellScript */,
+				0CF3CF22A2FCCC42E0636E51 /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				D25225EE73375F974FEA3678 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				03E2B5B72E8664AB00A8C8DA /* Sahara */,
@@ -210,6 +315,23 @@
 			productName = Sahara;
 			productReference = 03E2B5B52E8664AB00A8C8DA /* Sahara.app */;
 			productType = "com.apple.product-type.application";
+		};
+		E45FD418C3D55D51C662192E /* SaharaWidget */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CB61CC5D02C375C634A66A57 /* Build configuration list for PBXNativeTarget "SaharaWidget" */;
+			buildPhases = (
+				934E7857321C41EB398AEEE6 /* Sources */,
+				99971638BA62160923E272A2 /* Frameworks */,
+				3FC3F5B1EE611E2B57CA2291 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SaharaWidget;
+			productName = SaharaWidget;
+			productReference = 1DB96372ED38F2E168CE54D0 /* SaharaWidget.appex */;
+			productType = "com.apple.product-type.app-extension";
 		};
 /* End PBXNativeTarget section */
 
@@ -259,6 +381,7 @@
 			targets = (
 				03E2B5B42E8664AB00A8C8DA /* Sahara */,
 				034694682EA127BF0003065C /* SaharaTests */,
+				E45FD418C3D55D51C662192E /* SaharaWidget */,
 			);
 		};
 /* End PBXProject section */
@@ -276,6 +399,17 @@
 			buildActionMask = 2147483647;
 			files = (
 				03E2B5CE2E8664E400A8C8DA /* .gitignore in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3FC3F5B1EE611E2B57CA2291 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				48B972EDA01A0D7DFAC497C8 /* Assets.xcassets in Resources */,
+				41F9CBFF45B2A7276A014737 /* Localizable.strings in Resources */,
+				A1F0E7C3D8B24A9F10C3E002 /* Galmuri11-Bold.ttf in Resources */,
+				A1F0E7C3D8B24A9F10C3E003 /* Galmuri14.ttf in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -322,6 +456,19 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		934E7857321C41EB398AEEE6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F6478EED89A88C5C9B8679BF /* SaharaWidgetBundle.swift in Sources */,
+				11EAA4A28534A849B54F71B8 /* SaharaWidget.swift in Sources */,
+				FCDBDE9C8938DB07A5B50AF6 /* WidgetEntryView.swift in Sources */,
+				35809AA4E121A6056CB56712 /* AppGroupContainer.swift in Sources */,
+				EA52C3608F29D4B30139A488 /* WidgetCardEntry.swift in Sources */,
+				AD85792DE201FA8468B3E41E /* OnThisDaySelector.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -330,7 +477,27 @@
 			target = 03E2B5B42E8664AB00A8C8DA /* Sahara */;
 			targetProxy = 0346946D2EA127BF0003065C /* PBXContainerItemProxy */;
 		};
+		D25225EE73375F974FEA3678 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SaharaWidget;
+			target = E45FD418C3D55D51C662192E /* SaharaWidget */;
+			targetProxy = 9F6C04DDB36FD24530F0AF49 /* PBXContainerItemProxy */;
+		};
 /* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		7F687188F77FC625DD9732CC /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				DDAE112A04E74E8EB5EDDB78 /* ko */,
+				47CD2822568FA817EC45BEE9 /* en */,
+				2FFA727C3FD2CBCD02C8459C /* ja */,
+				2248A9DE1AE24A3DFBF50CFE /* zh-Hans */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
 		034694702EA127BF0003065C /* Debug */ = {
@@ -593,6 +760,67 @@
 			};
 			name = Release;
 		};
+		30D85514C2ABA88B1B791834 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_ENTITLEMENTS = SaharaWidget/SaharaWidget.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = RFZY2ACQ74;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = SaharaWidget/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = SaharaWidget;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.6.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.miya.Sahara.dev.SaharaWidget;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		71432FE0BBF79E6C7B525E45 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_ENTITLEMENTS = SaharaWidget/SaharaWidget.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = RFZY2ACQ74;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = SaharaWidget/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = SaharaWidget;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.6.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.miya.Sahara.SaharaWidget;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -619,6 +847,15 @@
 			buildConfigurations = (
 				03E2B5C92E8664AD00A8C8DA /* Debug */,
 				03E2B5CA2E8664AD00A8C8DA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CB61CC5D02C375C634A66A57 /* Build configuration list for PBXNativeTarget "SaharaWidget" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				71432FE0BBF79E6C7B525E45 /* Release */,
+				30D85514C2ABA88B1B791834 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Sahara/AppDelegate.swift
+++ b/Sahara/AppDelegate.swift
@@ -41,6 +41,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
         }
 
+        WidgetDataManager.shared.refreshWidgetData()
+
         return true
     }
 

--- a/Sahara/Common/Manager/WidgetDataManager.swift
+++ b/Sahara/Common/Manager/WidgetDataManager.swift
@@ -1,0 +1,181 @@
+//
+//  WidgetDataManager.swift
+//  Sahara
+//
+//  Created by 금가경 on 3/11/26.
+//
+
+import Foundation
+import OSLog
+import UIKit
+import WidgetKit
+
+final class WidgetDataManager {
+    static let shared = WidgetDataManager()
+    static let thumbnailPoolSize = 10
+
+    private let realmManager: RealmManagerProtocol
+    private let widgetDirectory: URL?
+    private let thumbnailsDirectory: URL?
+    private let cardStoreURL: URL?
+    private let queue = DispatchQueue(label: "com.sahara.widgetData", qos: .utility)
+
+    init(
+        realmManager: RealmManagerProtocol = RealmManager.shared,
+        widgetDirectory: URL? = AppGroupContainer.widgetDirectory,
+        thumbnailsDirectory: URL? = AppGroupContainer.thumbnailsDirectory,
+        cardStoreURL: URL? = AppGroupContainer.cardStoreURL
+    ) {
+        self.realmManager = realmManager
+        self.widgetDirectory = widgetDirectory
+        self.thumbnailsDirectory = thumbnailsDirectory
+        self.cardStoreURL = cardStoreURL
+    }
+
+    func refreshWidgetData(completion: (() -> Void)? = nil) {
+        guard widgetDirectory != nil else {
+            completion?()
+            return
+        }
+        queue.async { [weak self] in
+            self?.performRefresh()
+            completion?()
+        }
+    }
+
+    private func performRefresh() {
+        guard let widgetDir = widgetDirectory,
+              let thumbsDir = thumbnailsDirectory,
+              let storeURL = cardStoreURL else { return }
+
+        let fm = FileManager.default
+        try? fm.createDirectory(at: widgetDir, withIntermediateDirectories: true)
+        try? fm.createDirectory(at: thumbsDir, withIntermediateDirectories: true)
+
+        let cards = realmManager.fetch(Card.self, filter: "isLocked == false", sortKey: "date", ascending: false)
+
+        let calendar = Calendar.current
+        let today = Date()
+        let todayComponents = calendar.dateComponents([.year, .month, .day], from: today)
+        let todayMonth = todayComponents.month
+        let todayDay = todayComponents.day
+        let todayYear = todayComponents.year
+
+        var allEntries: [WidgetCardEntry] = []
+        var onThisDayCardIds: Set<String> = []
+        var otherCardIds: [String] = []
+        var cardLookup: [String: Card] = [:]
+
+        for card in cards {
+            let cardId = card.id.stringValue
+            let components = calendar.dateComponents([.month, .day], from: card.date)
+            guard let month = components.month, let day = components.day else { continue }
+
+            allEntries.append(WidgetCardEntry(
+                cardId: cardId,
+                date: card.date,
+                memo: card.memo,
+                monthDay: .init(month: month, day: day),
+                thumbnailFileName: nil
+            ))
+            cardLookup[cardId] = card
+
+            let cardYear = calendar.component(.year, from: card.date)
+            if month == todayMonth && day == todayDay && cardYear != todayYear {
+                onThisDayCardIds.insert(cardId)
+            } else {
+                otherCardIds.append(cardId)
+            }
+        }
+
+        let randomPool = otherCardIds.shuffled().prefix(Self.thumbnailPoolSize)
+        let thumbnailTargetIds = onThisDayCardIds.union(randomPool)
+
+        var validFileNames: Set<String> = []
+
+        for i in 0..<allEntries.count {
+            let entry = allEntries[i]
+            guard thumbnailTargetIds.contains(entry.cardId),
+                  let card = cardLookup[entry.cardId] else { continue }
+
+            let fileName: String
+            if let cached = existingThumbnailFileName(cardId: entry.cardId, directory: thumbsDir) {
+                fileName = cached
+            } else {
+                guard let imageData = card.resolvedImageData(),
+                      let generated = generateThumbnail(cardId: entry.cardId, imageData: imageData, directory: thumbsDir) else {
+                    continue
+                }
+                fileName = generated
+            }
+
+            validFileNames.insert(fileName)
+            allEntries[i] = WidgetCardEntry(
+                cardId: entry.cardId,
+                date: entry.date,
+                memo: entry.memo,
+                monthDay: entry.monthDay,
+                thumbnailFileName: fileName
+            )
+        }
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        if let data = try? encoder.encode(allEntries) {
+            try? data.write(to: storeURL, options: .atomic)
+        }
+
+        cleanupOrphanedThumbnails(in: thumbsDir, validFileNames: validFileNames)
+
+        reloadWidgetTimelines()
+    }
+
+    private func existingThumbnailFileName(cardId: String, directory: URL) -> String? {
+        for ext in ["jpg", "png"] {
+            let name = "\(cardId)_widget.\(ext)"
+            let url = directory.appendingPathComponent(name)
+            if FileManager.default.fileExists(atPath: url.path) {
+                return name
+            }
+        }
+        return nil
+    }
+
+    private func generateThumbnail(cardId: String, imageData: Data, directory: URL) -> String? {
+        guard let thumbnail = ImageDownsampler.downsample(data: imageData, maxDimension: 800) else {
+            return nil
+        }
+
+        let hasAlpha = thumbnail.hasAlphaChannel
+        let ext = hasAlpha ? "png" : "jpg"
+        let fileName = "\(cardId)_widget.\(ext)"
+        let fileURL = directory.appendingPathComponent(fileName)
+
+        let thumbnailData: Data?
+        if hasAlpha {
+            thumbnailData = thumbnail.pngData()
+        } else {
+            thumbnailData = thumbnail.jpegData(compressionQuality: 0.7)
+        }
+
+        guard let data = thumbnailData else { return nil }
+
+        do {
+            try data.write(to: fileURL, options: .atomic)
+            return fileName
+        } catch {
+            return nil
+        }
+    }
+
+    private func reloadWidgetTimelines() {
+        WidgetCenter.shared.reloadAllTimelines()
+    }
+
+    private func cleanupOrphanedThumbnails(in directory: URL, validFileNames: Set<String>) {
+        guard let files = try? FileManager.default.contentsOfDirectory(atPath: directory.path) else { return }
+        for file in files where !validFileNames.contains(file) {
+            try? FileManager.default.removeItem(at: directory.appendingPathComponent(file))
+        }
+    }
+}

--- a/Sahara/Common/Model/WidgetCardEntry.swift
+++ b/Sahara/Common/Model/WidgetCardEntry.swift
@@ -1,0 +1,21 @@
+//
+//  WidgetCardEntry.swift
+//  Sahara
+//
+//  Created by 금가경 on 3/11/26.
+//
+
+import Foundation
+
+struct WidgetCardEntry: Codable {
+    let cardId: String
+    let date: Date
+    let memo: String?
+    let monthDay: MonthDay
+    let thumbnailFileName: String?
+
+    struct MonthDay: Codable, Equatable {
+        let month: Int
+        let day: Int
+    }
+}

--- a/Sahara/Common/Utility/AppGroupContainer.swift
+++ b/Sahara/Common/Utility/AppGroupContainer.swift
@@ -1,0 +1,29 @@
+//
+//  AppGroupContainer.swift
+//  Sahara
+//
+//  Created by 금가경 on 3/11/26.
+//
+
+import Foundation
+
+enum AppGroupContainer {
+    static let groupIdentifier = "group.com.miya.Sahara"
+    static let widgetURLScheme = "saharaapp"
+
+    static var containerURL: URL? {
+        FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: groupIdentifier)
+    }
+
+    static var widgetDirectory: URL? {
+        containerURL?.appendingPathComponent("widget", isDirectory: true)
+    }
+
+    static var thumbnailsDirectory: URL? {
+        widgetDirectory?.appendingPathComponent("thumbnails", isDirectory: true)
+    }
+
+    static var cardStoreURL: URL? {
+        widgetDirectory?.appendingPathComponent("WidgetCardStore.json")
+    }
+}

--- a/Sahara/Common/Utility/OnThisDaySelector.swift
+++ b/Sahara/Common/Utility/OnThisDaySelector.swift
@@ -1,0 +1,40 @@
+//
+//  OnThisDaySelector.swift
+//  Sahara
+//
+//  Created by 금가경 on 3/11/26.
+//
+
+import Foundation
+
+struct SelectedCard {
+    let entry: WidgetCardEntry
+    let isOnThisDay: Bool
+}
+
+enum OnThisDaySelector {
+    static func select(from entries: [WidgetCardEntry], today: Date = Date()) -> SelectedCard? {
+        guard !entries.isEmpty else { return nil }
+
+        let calendar = Calendar.current
+        let todayComponents = calendar.dateComponents([.year, .month, .day], from: today)
+        guard let todayMonth = todayComponents.month,
+              let todayDay = todayComponents.day,
+              let todayYear = todayComponents.year else {
+            return entries.randomElement().map { SelectedCard(entry: $0, isOnThisDay: false) }
+        }
+
+        let onThisDayEntries = entries.filter { entry in
+            entry.monthDay.month == todayMonth
+            && entry.monthDay.day == todayDay
+            && calendar.component(.year, from: entry.date) != todayYear
+        }
+
+        if let selected = onThisDayEntries.randomElement() {
+            return SelectedCard(entry: selected, isOnThisDay: true)
+        }
+
+        guard let selected = entries.randomElement() else { return nil }
+        return SelectedCard(entry: selected, isOnThisDay: false)
+    }
+}

--- a/Sahara/Feature/CardInfo/CardInfoViewModel.swift
+++ b/Sahara/Feature/CardInfo/CardInfoViewModel.swift
@@ -202,6 +202,7 @@ final class CardInfoViewModel: BaseViewModelProtocol {
             .do(onNext: { [weak self] _ in
                 guard let self = self else { return }
                 shouldPopToListOnDeleteRelay.accept(self.sourceType != nil)
+                WidgetDataManager.shared.refreshWidgetData()
             })
     }
 
@@ -402,6 +403,7 @@ final class CardInfoViewModel: BaseViewModelProtocol {
                 return self.realmManager.add(card)
                     .do(onNext: {
                         self.logSaveAnalytics(isFirstCard: analyticsCtx.isFirstCard, hadLocationBefore: analyticsCtx.hadLocationBefore, location: location)
+                        WidgetDataManager.shared.refreshWidgetData()
                     })
             }
     }
@@ -503,6 +505,7 @@ final class CardInfoViewModel: BaseViewModelProtocol {
                 ImageFileManager.shared.deleteImageFile(at: oldPath)
             }
             ThumbnailCache.shared.invalidate(for: cardId)
+            WidgetDataManager.shared.refreshWidgetData()
         })
     }
 
@@ -627,6 +630,7 @@ final class CardInfoViewModel: BaseViewModelProtocol {
                 ImageFileManager.shared.deleteImageFile(at: oldPath)
             }
             ThumbnailCache.shared.invalidate(for: cardId)
+            WidgetDataManager.shared.refreshWidgetData()
         })
     }
 

--- a/Sahara/Info.plist
+++ b/Sahara/Info.plist
@@ -83,6 +83,17 @@
 			</array>
 		</dict>
 	</array>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>saharaapp</string>
+			</array>
+			<key>CFBundleURLName</key>
+			<string>com.miya.Sahara.widget</string>
+		</dict>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleLocalizations</key>

--- a/Sahara/Sahara.entitlements
+++ b/Sahara/Sahara.entitlements
@@ -4,6 +4,10 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.miya.Sahara</string>
+	</array>
 	<key>com.apple.security.device.camera</key>
 	<true/>
 	<key>com.apple.security.personal-information.photos-library</key>

--- a/Sahara/SceneDelegate.swift
+++ b/Sahara/SceneDelegate.swift
@@ -6,6 +6,7 @@
 //
 
 import MessageUI
+import RealmSwift
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
@@ -35,14 +36,23 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         window?.makeKeyAndVisible()
 
-        if let urlContext = connectionOptions.urlContexts.first {
-            handleBackupFileImport(url: urlContext.url)
+        if let url = connectionOptions.urlContexts.first?.url {
+            if url.scheme == AppGroupContainer.widgetURLScheme {
+                handleWidgetDeepLink(url: url)
+            } else {
+                handleBackupFileImport(url: url)
+            }
         }
     }
 
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
-        guard let urlContext = URLContexts.first else { return }
-        handleBackupFileImport(url: urlContext.url)
+        guard let url = URLContexts.first?.url else { return }
+
+        if url.scheme == AppGroupContainer.widgetURLScheme {
+            handleWidgetDeepLink(url: url)
+        } else {
+            handleBackupFileImport(url: url)
+        }
     }
 
     private func showRealmFailureAlert(on viewController: UIViewController) {
@@ -171,9 +181,25 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneWillEnterForeground(_ scene: UIScene) {
         UIApplication.shared.applicationIconBadgeNumber = 0
         UNUserNotificationCenter.current().removeAllDeliveredNotifications()
+        WidgetDataManager.shared.refreshWidgetData()
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {
+    }
+
+    private func handleWidgetDeepLink(url: URL) {
+        guard url.host == "card",
+              let cardIdString = url.pathComponents.last,
+              let objectId = try? ObjectId(string: cardIdString) else { return }
+
+        guard let tabBarController = window?.rootViewController as? MainTabBarController else { return }
+        tabBarController.selectedIndex = 0
+
+        guard let navController = tabBarController.selectedViewController as? UINavigationController else { return }
+        navController.popToRootViewController(animated: false)
+
+        let detailVC = CardDetailViewController(cardId: objectId)
+        navController.pushViewController(detailVC, animated: true)
     }
 
     private func handleBackupFileImport(url: URL) {
@@ -228,6 +254,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                     }
                 }
                 DispatchQueue.main.async {
+                    WidgetDataManager.shared.refreshWidgetData()
                     progressAlert.alert.dismiss(animated: true) {
                         self?.showImportSuccess()
                     }

--- a/SaharaTests/Mocks/MockRealmManager.swift
+++ b/SaharaTests/Mocks/MockRealmManager.swift
@@ -40,7 +40,11 @@ final class MockRealmManager: RealmManagerProtocol {
 
     func fetch<T: Object>(_ type: T.Type, filter: String?, sortKey: String?, ascending: Bool) -> [T] {
         fetchCalled = true
-        return mockCards as? [T] ?? []
+        var cards = mockCards
+        if let filter = filter, filter.contains("isLocked == false") {
+            cards = cards.filter { !$0.isLocked }
+        }
+        return cards as? [T] ?? []
     }
 
     func fetchObject<T: Object>(_ type: T.Type, forPrimaryKey key: Any) -> T? {

--- a/SaharaTests/OnThisDaySelectorTests.swift
+++ b/SaharaTests/OnThisDaySelectorTests.swift
@@ -1,0 +1,108 @@
+//
+//  OnThisDaySelectorTests.swift
+//  SaharaTests
+//
+//  Created by 금가경 on 3/11/26.
+//
+
+import XCTest
+@testable import Sahara
+
+final class OnThisDaySelectorTests: XCTestCase {
+
+    private func makeEntry(
+        cardId: String = UUID().uuidString,
+        date: Date,
+        memo: String? = nil
+    ) -> WidgetCardEntry {
+        let calendar = Calendar.current
+        let components = calendar.dateComponents([.month, .day], from: date)
+        return WidgetCardEntry(
+            cardId: cardId,
+            date: date,
+            memo: memo,
+            monthDay: .init(month: components.month!, day: components.day!),
+            thumbnailFileName: "\(cardId)_widget.jpg"
+        )
+    }
+
+    private func date(year: Int, month: Int, day: Int) -> Date {
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = day
+        return Calendar.current.date(from: components)!
+    }
+
+    func test_onThisDay_prefersPreviousYearSameDate() {
+        let today = date(year: 2026, month: 3, day: 11)
+        let lastYear = makeEntry(cardId: "old", date: date(year: 2025, month: 3, day: 11))
+        let otherDay = makeEntry(cardId: "other", date: date(year: 2025, month: 5, day: 20))
+        let entries = [lastYear, otherDay]
+
+        for _ in 0..<20 {
+            guard let result = OnThisDaySelector.select(from: entries, today: today) else {
+                XCTFail("Expected a selection")
+                return
+            }
+            XCTAssertEqual(result.entry.cardId, "old")
+            XCTAssertTrue(result.isOnThisDay)
+        }
+    }
+
+    func test_onThisDay_leapYearFeb29() {
+        let today = date(year: 2028, month: 2, day: 29)
+        let leapEntry = makeEntry(cardId: "leap", date: date(year: 2024, month: 2, day: 29))
+        let otherEntry = makeEntry(cardId: "other", date: date(year: 2025, month: 6, day: 15))
+
+        guard let result = OnThisDaySelector.select(from: [leapEntry, otherEntry], today: today) else {
+            XCTFail("Expected a selection")
+            return
+        }
+        XCTAssertEqual(result.entry.cardId, "leap")
+        XCTAssertTrue(result.isOnThisDay)
+    }
+
+    func test_onThisDay_excludesTodayCards() {
+        let today = date(year: 2026, month: 3, day: 11)
+        let todayEntry = makeEntry(cardId: "today", date: today)
+        let otherEntry = makeEntry(cardId: "other", date: date(year: 2026, month: 1, day: 5))
+
+        for _ in 0..<20 {
+            guard let result = OnThisDaySelector.select(from: [todayEntry, otherEntry], today: today) else {
+                XCTFail("Expected a selection")
+                return
+            }
+            XCTAssertFalse(result.isOnThisDay)
+        }
+    }
+
+    func test_onThisDay_excludesTodayCards_multipleSameDayEntries() {
+        let today = date(year: 2026, month: 3, day: 11)
+        let todayEntry1 = makeEntry(cardId: "today1", date: today)
+        let todayEntry2 = makeEntry(cardId: "today2", date: today)
+
+        guard let result = OnThisDaySelector.select(from: [todayEntry1, todayEntry2], today: today) else {
+            XCTFail("Expected a selection")
+            return
+        }
+        XCTAssertFalse(result.isOnThisDay)
+    }
+
+    func test_fallbackToRandom_whenNoOnThisDay() {
+        let today = date(year: 2026, month: 3, day: 11)
+        let entry = makeEntry(cardId: "only", date: date(year: 2025, month: 7, day: 20))
+
+        guard let result = OnThisDaySelector.select(from: [entry], today: today) else {
+            XCTFail("Expected a selection")
+            return
+        }
+        XCTAssertEqual(result.entry.cardId, "only")
+        XCTAssertFalse(result.isOnThisDay)
+    }
+
+    func test_emptyEntries_returnsNil() {
+        let result = OnThisDaySelector.select(from: [])
+        XCTAssertNil(result)
+    }
+}

--- a/SaharaTests/WidgetDataManagerTests.swift
+++ b/SaharaTests/WidgetDataManagerTests.swift
@@ -1,0 +1,198 @@
+//
+//  WidgetDataManagerTests.swift
+//  SaharaTests
+//
+//  Created by 금가경 on 3/11/26.
+//
+
+import XCTest
+import RealmSwift
+@testable import Sahara
+
+final class WidgetDataManagerTests: XCTestCase {
+    var testDirectory: URL!
+    var thumbnailsDirectory: URL!
+    var cardStoreURL: URL!
+    var mockRealmManager: MockRealmManager!
+
+    override func setUp() {
+        super.setUp()
+        testDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WidgetDataManagerTests-\(UUID().uuidString)")
+        thumbnailsDirectory = testDirectory.appendingPathComponent("thumbnails")
+        cardStoreURL = testDirectory.appendingPathComponent("WidgetCardStore.json")
+        try? FileManager.default.createDirectory(at: testDirectory, withIntermediateDirectories: true)
+        mockRealmManager = MockRealmManager()
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: testDirectory)
+        testDirectory = nil
+        thumbnailsDirectory = nil
+        cardStoreURL = nil
+        mockRealmManager = nil
+        super.tearDown()
+    }
+
+    private func makeSut() -> WidgetDataManager {
+        WidgetDataManager(
+            realmManager: mockRealmManager,
+            widgetDirectory: testDirectory,
+            thumbnailsDirectory: thumbnailsDirectory,
+            cardStoreURL: cardStoreURL
+        )
+    }
+
+    private func makeCard(date: Date = Date(), isLocked: Bool = false, withImage: Bool = true) -> Card {
+        Card(
+            date: date,
+            createdDate: Date(),
+            editedImageData: withImage ? createTestImageData() : nil,
+            memo: "Test memo",
+            isLocked: isLocked
+        )
+    }
+
+    private func loadEntries() -> [WidgetCardEntry] {
+        guard let data = try? Data(contentsOf: cardStoreURL) else { return [] }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return (try? decoder.decode([WidgetCardEntry].self, from: data)) ?? []
+    }
+
+    private func createTestImageData() -> Data {
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: 100, height: 100))
+        return renderer.jpegData(withCompressionQuality: 0.5) { context in
+            UIColor.red.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: 100, height: 100))
+        }
+    }
+
+    func test_refreshWidgetData_writesValidJSON() {
+        let card = makeCard()
+        mockRealmManager.mockCards = [card]
+        let sut = makeSut()
+        let expectation = XCTestExpectation(description: "Widget data refreshed")
+
+        sut.refreshWidgetData {
+            let exists = FileManager.default.fileExists(atPath: self.cardStoreURL.path)
+            XCTAssertTrue(exists, "JSON file should be created")
+
+            let entries = self.loadEntries()
+            XCTAssertEqual(entries.count, 1)
+            XCTAssertEqual(entries.first?.cardId, card.id.stringValue)
+
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 10)
+    }
+
+    func test_refreshWidgetData_excludesLockedCards() {
+        let unlockedCard = makeCard(isLocked: false)
+        let lockedCard = makeCard(isLocked: true)
+        mockRealmManager.mockCards = [unlockedCard, lockedCard]
+        let sut = makeSut()
+        let expectation = XCTestExpectation(description: "Widget data refreshed")
+
+        sut.refreshWidgetData {
+            let entries = self.loadEntries()
+            let lockedIds = entries.filter { $0.cardId == lockedCard.id.stringValue }
+            XCTAssertTrue(lockedIds.isEmpty, "Locked cards should be excluded")
+
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 10)
+    }
+
+    func test_refreshWidgetData_cleanupOrphanedThumbnails() {
+        let card = makeCard()
+        mockRealmManager.mockCards = [card]
+        let sut = makeSut()
+
+        try? FileManager.default.createDirectory(at: thumbnailsDirectory, withIntermediateDirectories: true)
+        let orphanURL = thumbnailsDirectory.appendingPathComponent("orphan_widget.jpg")
+        try? Data([0xFF]).write(to: orphanURL)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: orphanURL.path))
+
+        let expectation = XCTestExpectation(description: "Orphan cleanup")
+
+        sut.refreshWidgetData {
+            XCTAssertFalse(
+                FileManager.default.fileExists(atPath: orphanURL.path),
+                "Orphaned thumbnail should be cleaned up"
+            )
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 10)
+    }
+
+    func test_refreshWidgetData_limitsThumbnailsToPoolSize() {
+        let cardCount = WidgetDataManager.thumbnailPoolSize + 10
+        let cards = (0..<cardCount).map { _ in makeCard() }
+        mockRealmManager.mockCards = cards
+        let sut = makeSut()
+        let expectation = XCTestExpectation(description: "Pool size limit")
+
+        sut.refreshWidgetData {
+            let entries = self.loadEntries()
+            XCTAssertEqual(entries.count, cardCount, "JSON should contain all cards")
+
+            let withThumbnails = entries.filter { $0.thumbnailFileName != nil }
+            XCTAssertLessThanOrEqual(
+                withThumbnails.count,
+                WidgetDataManager.thumbnailPoolSize,
+                "Thumbnails should be limited to pool size"
+            )
+
+            let thumbFiles = (try? FileManager.default.contentsOfDirectory(atPath: self.thumbnailsDirectory.path)) ?? []
+            XCTAssertLessThanOrEqual(
+                thumbFiles.count,
+                WidgetDataManager.thumbnailPoolSize,
+                "Thumbnail files on disk should be limited to pool size"
+            )
+
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 10)
+    }
+
+    func test_refreshWidgetData_alwaysIncludesOnThisDayCandidates() {
+        let calendar = Calendar.current
+        let today = Date()
+        let todayComponents = calendar.dateComponents([.month, .day], from: today)
+        var lastYearComponents = DateComponents()
+        lastYearComponents.year = calendar.component(.year, from: today) - 1
+        lastYearComponents.month = todayComponents.month
+        lastYearComponents.day = todayComponents.day
+        let lastYearDate = calendar.date(from: lastYearComponents)!
+
+        let onThisDayCard = makeCard(date: lastYearDate)
+        var otherCards = (0..<WidgetDataManager.thumbnailPoolSize + 5).map { i -> Card in
+            let offset = -(i + 30)
+            let date = calendar.date(byAdding: .day, value: offset, to: today)!
+            return makeCard(date: date)
+        }
+        otherCards.append(onThisDayCard)
+        mockRealmManager.mockCards = otherCards
+        let sut = makeSut()
+        let expectation = XCTestExpectation(description: "On this day included")
+
+        sut.refreshWidgetData {
+            let entries = self.loadEntries()
+            let onThisDayEntry = entries.first { $0.cardId == onThisDayCard.id.stringValue }
+            XCTAssertNotNil(onThisDayEntry, "On-this-day card should be in JSON")
+            XCTAssertNotNil(
+                onThisDayEntry?.thumbnailFileName,
+                "On-this-day card should always have a thumbnail"
+            )
+
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 10)
+    }
+}

--- a/SaharaWidget/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/SaharaWidget/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"idiom":"universal"}],"info":{"version":1,"author":"xcode"}}

--- a/SaharaWidget/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/SaharaWidget/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,1 @@
+{"images":[{"idiom":"universal","platform":"ios","size":"1024x1024"}],"info":{"version":1,"author":"xcode"}}

--- a/SaharaWidget/Assets.xcassets/Contents.json
+++ b/SaharaWidget/Assets.xcassets/Contents.json
@@ -1,0 +1,1 @@
+{"info":{"version":1,"author":"xcode"}}

--- a/SaharaWidget/Assets.xcassets/WidgetBackground.colorset/Contents.json
+++ b/SaharaWidget/Assets.xcassets/WidgetBackground.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"idiom":"universal"}],"info":{"version":1,"author":"xcode"}}

--- a/SaharaWidget/Info.plist
+++ b/SaharaWidget/Info.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+	<key>UIAppFonts</key>
+	<array>
+		<string>Galmuri11-Bold.ttf</string>
+		<string>Galmuri14.ttf</string>
+	</array>
+</dict>
+</plist>

--- a/SaharaWidget/Resources/en.lproj/Localizable.strings
+++ b/SaharaWidget/Resources/en.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* Widget */
+"widget.display_name" = "Sahara";
+"widget.description" = "Shows today's memory";
+"widget.on_this_day" = "On This Day";
+"widget.empty_message" = "Create your first card";
+"widget.placeholder_memo" = "Today's memory";
+"widget.date_format" = "MMMM d, yyyy";

--- a/SaharaWidget/Resources/ja.lproj/Localizable.strings
+++ b/SaharaWidget/Resources/ja.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* Widget */
+"widget.display_name" = "サハラ";
+"widget.description" = "今日の思い出を表示します";
+"widget.on_this_day" = "この日の思い出";
+"widget.empty_message" = "カードを作ってみましょう";
+"widget.placeholder_memo" = "今日の記憶";
+"widget.date_format" = "yyyy年MM月dd日";

--- a/SaharaWidget/Resources/ko.lproj/Localizable.strings
+++ b/SaharaWidget/Resources/ko.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* Widget */
+"widget.display_name" = "사하라";
+"widget.description" = "오늘의 추억을 보여줍니다";
+"widget.on_this_day" = "이날의 추억";
+"widget.empty_message" = "카드를 만들어보세요";
+"widget.placeholder_memo" = "오늘의 기억";
+"widget.date_format" = "yyyy년 MM월 dd일";

--- a/SaharaWidget/Resources/zh-Hans.lproj/Localizable.strings
+++ b/SaharaWidget/Resources/zh-Hans.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* Widget */
+"widget.display_name" = "沙漠";
+"widget.description" = "显示今天的回忆";
+"widget.on_this_day" = "那年今日";
+"widget.empty_message" = "创建你的第一张卡片";
+"widget.placeholder_memo" = "今日的记忆";
+"widget.date_format" = "yyyy年MM月dd日";

--- a/SaharaWidget/SaharaWidget.entitlements
+++ b/SaharaWidget/SaharaWidget.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.miya.Sahara</string>
+	</array>
+</dict>
+</plist>

--- a/SaharaWidget/SaharaWidget.swift
+++ b/SaharaWidget/SaharaWidget.swift
@@ -1,0 +1,132 @@
+//
+//  SaharaWidget.swift
+//  SaharaWidget
+//
+//  Created by 금가경 on 3/11/26.
+//
+
+import SwiftUI
+import WidgetKit
+
+struct SaharaWidgetEntry: TimelineEntry {
+    let date: Date
+    let cardId: String?
+    let cardDate: Date?
+    let memo: String?
+    let thumbnailImage: UIImage?
+    let isOnThisDay: Bool
+    let isEmpty: Bool
+}
+
+struct SaharaWidgetProvider: TimelineProvider {
+    func placeholder(in context: Context) -> SaharaWidgetEntry {
+        SaharaWidgetEntry(
+            date: Date(),
+            cardId: nil,
+            cardDate: nil,
+            memo: NSLocalizedString("widget.placeholder_memo", comment: ""),
+            thumbnailImage: nil,
+            isOnThisDay: false,
+            isEmpty: false
+        )
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (SaharaWidgetEntry) -> Void) {
+        let entry = loadEntry()
+        completion(entry)
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<SaharaWidgetEntry>) -> Void) {
+        let entry = loadEntry()
+        let nextUpdate = Calendar.current.date(byAdding: .hour, value: 4, to: Date()) ?? Date()
+        let timeline = Timeline(entries: [entry], policy: .after(nextUpdate))
+        completion(timeline)
+    }
+
+    private func loadEntry() -> SaharaWidgetEntry {
+        let entries = loadCardEntries()
+
+        guard let selected = OnThisDaySelector.select(from: entries) else {
+            return SaharaWidgetEntry(
+                date: Date(),
+                cardId: nil,
+                cardDate: nil,
+                memo: nil,
+                thumbnailImage: nil,
+                isOnThisDay: false,
+                isEmpty: true
+            )
+        }
+
+        if let fileName = selected.entry.thumbnailFileName,
+           let thumbnail = loadThumbnail(fileName: fileName) {
+            return SaharaWidgetEntry(
+                date: Date(),
+                cardId: selected.entry.cardId,
+                cardDate: selected.entry.date,
+                memo: selected.entry.memo,
+                thumbnailImage: thumbnail,
+                isOnThisDay: selected.isOnThisDay,
+                isEmpty: false
+            )
+        }
+
+        let entriesWithThumbnails = entries.filter { $0.thumbnailFileName != nil }
+        if let fallback = OnThisDaySelector.select(from: entriesWithThumbnails),
+           let fileName = fallback.entry.thumbnailFileName,
+           let thumbnail = loadThumbnail(fileName: fileName) {
+            return SaharaWidgetEntry(
+                date: Date(),
+                cardId: fallback.entry.cardId,
+                cardDate: fallback.entry.date,
+                memo: fallback.entry.memo,
+                thumbnailImage: thumbnail,
+                isOnThisDay: fallback.isOnThisDay,
+                isEmpty: false
+            )
+        }
+
+        return SaharaWidgetEntry(
+            date: Date(),
+            cardId: selected.entry.cardId,
+            cardDate: selected.entry.date,
+            memo: selected.entry.memo,
+            thumbnailImage: nil,
+            isOnThisDay: selected.isOnThisDay,
+            isEmpty: false
+        )
+    }
+
+    private func loadCardEntries() -> [WidgetCardEntry] {
+        guard let storeURL = AppGroupContainer.cardStoreURL,
+              let data = try? Data(contentsOf: storeURL) else {
+            return []
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return (try? decoder.decode([WidgetCardEntry].self, from: data)) ?? []
+    }
+
+    private func loadThumbnail(fileName: String) -> UIImage? {
+        guard let thumbsDir = AppGroupContainer.thumbnailsDirectory else { return nil }
+        let url = thumbsDir.appendingPathComponent(fileName)
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return UIImage(data: data)
+    }
+}
+
+struct SaharaWidget: Widget {
+    let kind = "SaharaWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: SaharaWidgetProvider()) { entry in
+            WidgetEntryView(entry: entry)
+                .containerBackground(for: .widget) { Color.clear }
+        }
+        .configurationDisplayName(NSLocalizedString("widget.display_name", comment: ""))
+        .description(NSLocalizedString("widget.description", comment: ""))
+        .supportedFamilies([.systemSmall, .systemLarge])
+        .contentMarginsDisabled()
+    }
+}

--- a/SaharaWidget/SaharaWidgetBundle.swift
+++ b/SaharaWidget/SaharaWidgetBundle.swift
@@ -1,0 +1,16 @@
+//
+//  SaharaWidgetBundle.swift
+//  SaharaWidget
+//
+//  Created by 금가경 on 3/11/26.
+//
+
+import SwiftUI
+import WidgetKit
+
+@main
+struct SaharaWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        SaharaWidget()
+    }
+}

--- a/SaharaWidget/WidgetEntryView.swift
+++ b/SaharaWidget/WidgetEntryView.swift
@@ -1,0 +1,109 @@
+//
+//  WidgetEntryView.swift
+//  SaharaWidget
+//
+//  Created by 금가경 on 3/11/26.
+//
+
+import SwiftUI
+import WidgetKit
+
+struct WidgetEntryView: View {
+    let entry: SaharaWidgetEntry
+
+    @Environment(\.widgetFamily) var family
+
+    var body: some View {
+        if entry.isEmpty {
+            emptyView
+        } else {
+            cardView
+                .widgetURL(cardURL)
+        }
+    }
+
+    private var cardURL: URL? {
+        guard let cardId = entry.cardId else { return nil }
+        return URL(string: "\(AppGroupContainer.widgetURLScheme)://card/\(cardId)")
+    }
+
+    private var emptyView: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "photo.on.rectangle.angled")
+                .font(.system(size: 32))
+                .foregroundColor(.secondary)
+            Text(NSLocalizedString("widget.empty_message", comment: ""))
+                .font(.custom("Galmuri11-Bold", size: 14))
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var cardView: some View {
+        GeometryReader { geometry in
+            ZStack {
+                if let image = entry.thumbnailImage {
+                    Image(uiImage: image)
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .frame(width: geometry.size.width, height: geometry.size.height)
+                        .clipped()
+                }
+
+                gradientOverlay(height: geometry.size.height)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Spacer()
+
+                    if entry.isOnThisDay {
+                        onThisDayBadge
+                    }
+
+                    if let cardDate = entry.cardDate {
+                        Text(formattedDate(cardDate))
+                            .font(.custom("Galmuri11-Bold", size: family == .systemLarge ? 16 : 13))
+                            .foregroundColor(.white.opacity(0.9))
+                    }
+
+                    if family == .systemLarge, let memo = entry.memo, !memo.isEmpty {
+                        Text(memo)
+                            .font(.custom("Galmuri14", size: 16))
+                            .foregroundColor(.white)
+                            .lineLimit(3)
+                    }
+                }
+                .padding(14)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    private func gradientOverlay(height: CGFloat) -> some View {
+        VStack(spacing: 0) {
+            Spacer()
+
+            LinearGradient(
+                gradient: Gradient(colors: [.clear, .black.opacity(0.6)]),
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .frame(height: height * 0.6)
+        }
+    }
+
+    private var onThisDayBadge: some View {
+        Text(NSLocalizedString("widget.on_this_day", comment: ""))
+            .font(.custom("Galmuri11-Bold", size: 12))
+            .foregroundColor(.white)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(Capsule().fill(Color.white.opacity(0.3)))
+    }
+
+    private func formattedDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = NSLocalizedString("widget.date_format", comment: "")
+        return formatter.string(from: date)
+    }
+}


### PR DESCRIPTION
Closes #49

## 변경 내용

**추가**
- 홈 화면 위젯 (Small/Large 크기 지원)
- "이날의 추억" 우선 선택 로직 — 같은 월/일의 과거 카드를 우선 표시
- 랜덤 풀 회전 방식의 썸네일 관리 — 매 갱신마다 10장의 썸네일만 유지하여 저장 용량 최적화 (카드 1,000장 기준 ~150MB → ~1.5MB)
- App Group을 통한 메인 앱-위젯 간 데이터 공유
- 위젯 탭 시 해당 카드 상세 화면으로 딥링크 이동
- 카드 저장/삭제/수정, 앱 진입, 백업 복원 시 위젯 데이터 자동 갱신
- 위젯 데이터 레이어 테스트 (풀 크기 제한, 이날의 추억 후보 포함 검증)

## 결정 근거

- **랜덤 풀 회전** — 전체 카드의 썸네일을 App Group에 저장하면 저장 용량이 선형 증가하므로, 매 갱신마다 10장만 교체하여 용량을 제한하면서 장기적으로 다양한 카드를 노출합니다
- **JSON 전체 메타데이터 유지** — OnThisDaySelector가 전체 카드 풀에서 후보를 선별해야 하므로, 썸네일은 제한하되 메타데이터는 전체 저장합니다
- **completion handler 테스트** — DispatchQueue.asyncAfter 기반 테스트는 타이밍에 따라 flaky하므로, refreshWidgetData에 completion handler를 추가하여 확정적 테스트를 구현했습니다