### PR TITLE
Cache Vision tags and decouple OCR from save chain

### DIFF
--- a/Sahara.xcodeproj/project.pbxproj
+++ b/Sahara.xcodeproj/project.pbxproj
@@ -28,12 +28,12 @@
 		41F9CBFF45B2A7276A014737 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 7F687188F77FC625DD9732CC /* Localizable.strings */; };
 		48B972EDA01A0D7DFAC497C8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FAF3F6268F7FE8A9ADB1A7EB /* Assets.xcassets */; };
 		9716DC354EDCBBF970FC7B1C /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5784B26A0B503F279A42BC75 /* Foundation.framework */; };
+		A1F0E7C3D8B24A9F10C3E002 /* Galmuri11-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A1F0E7C3D8B24A9F10C3F002 /* Galmuri11-Bold.ttf */; };
+		A1F0E7C3D8B24A9F10C3E003 /* Galmuri14.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A1F0E7C3D8B24A9F10C3F003 /* Galmuri14.ttf */; };
 		AD85792DE201FA8468B3E41E /* OnThisDaySelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44A26D12CF118BD5052ABBF6 /* OnThisDaySelector.swift */; };
 		EA52C3608F29D4B30139A488 /* WidgetCardEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116F65DEB3596628C0C1D92 /* WidgetCardEntry.swift */; };
 		F6478EED89A88C5C9B8679BF /* SaharaWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FC5D9D4D4DD259374C87E64 /* SaharaWidgetBundle.swift */; };
 		FCDBDE9C8938DB07A5B50AF6 /* WidgetEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A0295F178A2885F15A30C0 /* WidgetEntryView.swift */; };
-		A1F0E7C3D8B24A9F10C3E002 /* Galmuri11-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A1F0E7C3D8B24A9F10C3F002 /* Galmuri11-Bold.ttf */; };
-		A1F0E7C3D8B24A9F10C3E003 /* Galmuri14.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A1F0E7C3D8B24A9F10C3F003 /* Galmuri14.ttf */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -105,12 +105,12 @@
 		5784B26A0B503F279A42BC75 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		9A08EFBD5AC7A29DB84BAB22 /* SaharaWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SaharaWidget.swift; sourceTree = "<group>"; };
 		9FC5D9D4D4DD259374C87E64 /* SaharaWidgetBundle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SaharaWidgetBundle.swift; sourceTree = "<group>"; };
+		A1F0E7C3D8B24A9F10C3F002 /* Galmuri11-Bold.ttf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = "Galmuri11-Bold.ttf"; path = "Sahara/Resources/Fonts/Galmuri11-Bold.ttf"; sourceTree = SOURCE_ROOT; };
+		A1F0E7C3D8B24A9F10C3F003 /* Galmuri14.ttf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = Galmuri14.ttf; path = Sahara/Resources/Fonts/Galmuri14.ttf; sourceTree = SOURCE_ROOT; };
 		CE323ED067314EE13712B049 /* WidgetKit.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
 		D1A0295F178A2885F15A30C0 /* WidgetEntryView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WidgetEntryView.swift; sourceTree = "<group>"; };
 		DDAE112A04E74E8EB5EDDB78 /* ko */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
 		FAF3F6268F7FE8A9ADB1A7EB /* Assets.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		A1F0E7C3D8B24A9F10C3F002 /* Galmuri11-Bold.ttf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = "Galmuri11-Bold.ttf"; path = "Sahara/Resources/Fonts/Galmuri11-Bold.ttf"; sourceTree = SOURCE_ROOT; };
-		A1F0E7C3D8B24A9F10C3F003 /* Galmuri14.ttf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = Galmuri14.ttf; path = Sahara/Resources/Fonts/Galmuri14.ttf; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */

--- a/Sahara/Common/Manager/CardPostProcessor.swift
+++ b/Sahara/Common/Manager/CardPostProcessor.swift
@@ -1,0 +1,176 @@
+//
+//  CardPostProcessor.swift
+//  Sahara
+//
+//  Created by 금가경 on 3/13/26.
+//
+
+import Foundation
+import OSLog
+import RealmSwift
+import UIKit
+import Vision
+
+protocol CardPostProcessorProtocol {
+    func process(cardId: ObjectId, imageData: Data)
+    func processUntaggedCards()
+}
+
+final class CardPostProcessor: CardPostProcessorProtocol {
+    static let shared = CardPostProcessor()
+
+    private let realmConfiguration: Realm.Configuration
+    private let queue = DispatchQueue(label: "com.sahara.postProcessor", qos: .utility)
+
+    init(realmConfiguration: Realm.Configuration? = nil) {
+        self.realmConfiguration = realmConfiguration ?? RealmManager.shared.createConfiguration()
+    }
+
+    func process(cardId: ObjectId, imageData: Data) {
+        queue.async { [weak self] in
+            self?.performProcess(cardId: cardId, imageData: imageData)
+        }
+    }
+
+    func processUntaggedCards() {
+        queue.async { [weak self] in
+            self?.performProcessUntagged()
+        }
+    }
+
+    private func performProcess(cardId: ObjectId, imageData: Data) {
+        guard let realm = try? Realm(configuration: realmConfiguration),
+              let card = realm.object(ofType: Card.self, forPrimaryKey: cardId) else {
+            return
+        }
+
+        let ocrText = recognizeTextSync(from: imageData)
+        let visionTags = classifyImageSync(from: imageData)
+
+        do {
+            try realm.write {
+                card.ocrText = ocrText
+                card.visionTags.removeAll()
+                card.visionTags.append(objectsIn: visionTags)
+            }
+            Logger.postProcessor.notice("[PostProcess] card=\(cardId.stringValue) ocr=\(ocrText != nil) tags=\(visionTags.map(\.rawValue))")
+        } catch {
+            Logger.postProcessor.error("[PostProcess] Realm write failed: \(error.localizedDescription)")
+        }
+    }
+
+    private func performProcessUntagged() {
+        guard let realm = try? Realm(configuration: realmConfiguration) else { return }
+
+        let allCards = realm.objects(Card.self)
+        let untaggedCards = allCards.filter { $0.visionTags.isEmpty }
+
+        Logger.postProcessor.notice("[PostProcess] Untagged cards: \(untaggedCards.count)/\(allCards.count)")
+
+        for card in untaggedCards {
+            guard let imageData = card.resolvedImageData() else { continue }
+            let cardId = card.id
+
+            let ocrText = recognizeTextSync(from: imageData)
+            let visionTags = classifyImageSync(from: imageData)
+
+            guard let freshCard = realm.object(ofType: Card.self, forPrimaryKey: cardId) else { continue }
+
+            do {
+                try realm.write {
+                    if freshCard.ocrText == nil {
+                        freshCard.ocrText = ocrText
+                    }
+                    freshCard.visionTags.removeAll()
+                    freshCard.visionTags.append(objectsIn: visionTags)
+                }
+            } catch {
+                Logger.postProcessor.error("[PostProcess] Batch write failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    private func recognizeTextSync(from imageData: Data) -> String? {
+        guard let image = ImageDownsampler.downsample(data: imageData, maxDimension: 2000),
+              let cgImage = image.cgImage else {
+            return nil
+        }
+
+        let request = VNRecognizeTextRequest()
+        request.recognitionLanguages = ["ko-KR", "en-US", "ja-JP"]
+        request.recognitionLevel = .accurate
+        request.usesLanguageCorrection = true
+
+        let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+        do {
+            try handler.perform([request])
+        } catch {
+            return nil
+        }
+
+        guard let observations = request.results else { return nil }
+        let texts = observations.compactMap { $0.topCandidates(1).first?.string }
+        let fullText = texts.joined(separator: " ")
+        return fullText.isEmpty ? nil : fullText
+    }
+
+    private func classifyImageSync(from imageData: Data) -> [VisionTag] {
+        guard let image = ImageDownsampler.downsample(data: imageData, maxDimension: 500),
+              let cgImage = image.cgImage else {
+            return []
+        }
+
+        let request = VNClassifyImageRequest()
+        let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+        do {
+            try handler.perform([request])
+        } catch {
+            return []
+        }
+
+        guard let observations = request.results else { return [] }
+        let topLabels = observations.prefix(5).map { $0.identifier }
+        return mapLabelsToVisionTags(topLabels)
+    }
+
+    func mapLabelsToVisionTags(_ labels: [String]) -> [VisionTag] {
+        let labelMapping: [String: VisionTag] = [
+            "person": .person, "face": .person, "people": .person, "human": .person, "portrait": .person, "selfie": .person,
+            "cat": .cat, "kitten": .cat, "feline": .cat,
+            "dog": .dog, "puppy": .dog, "canine": .dog,
+            "bird": .bird,
+            "food": .food, "meal": .food, "dish": .food, "fruit": .food, "vegetable": .food, "cuisine": .food, "dessert": .food, "bread": .food, "meat": .food, "pizza": .food,
+            "drink": .drink, "beverage": .drink, "coffee": .drink, "tea": .drink,
+            "nature": .nature, "landscape": .nature, "plant": .nature, "forest": .nature,
+            "sky": .sky, "cloud": .sky,
+            "sunset": .sunset, "sunrise": .sunset,
+            "flower": .flower,
+            "tree": .tree,
+            "ocean": .ocean, "sea": .ocean, "beach": .ocean, "water": .ocean,
+            "mountain": .mountain,
+            "building": .building, "architecture": .building, "house": .building, "structure": .building, "tower": .building, "bridge": .building,
+            "landmark": .landmark,
+            "indoor": .indoor,
+            "outdoor": .outdoor,
+            "car": .car,
+            "bicycle": .bicycle,
+            "text": .text,
+            "screenshot": .screenshot
+        ]
+
+        var result: [VisionTag] = []
+        var seen = Set<VisionTag>()
+
+        for label in labels {
+            let lowercased = label.lowercased()
+            for (keyword, tag) in labelMapping {
+                if lowercased.contains(keyword) && !seen.contains(tag) {
+                    result.append(tag)
+                    seen.insert(tag)
+                }
+            }
+        }
+
+        return result
+    }
+}

--- a/Sahara/Common/Utility/Logger+Extensions.swift
+++ b/Sahara/Common/Utility/Logger+Extensions.swift
@@ -20,6 +20,7 @@ extension Logger {
         case cardInfo
         case realmManager
         case performance
+        case postProcessor
     }
 
     static func logger(subsystem: Subsystem, category: Category) -> Logger {
@@ -31,6 +32,7 @@ extension Logger {
     static let cardInfo = logger(subsystem: .ui, category: .cardInfo)
     static let database = logger(subsystem: .database, category: .realmManager)
     static let performance = logger(subsystem: .ui, category: .performance)
+    static let postProcessor = logger(subsystem: .imageProcessing, category: .postProcessor)
 }
 
 extension Int? {

--- a/Sahara/Feature/CardInfo/CardInfoViewModel.swift
+++ b/Sahara/Feature/CardInfo/CardInfoViewModel.swift
@@ -23,7 +23,7 @@ enum EditSourceType {
 final class CardInfoViewModel: BaseViewModelProtocol {
     private let disposeBag = DisposeBag()
     private let realmManager: RealmManagerProtocol
-    private let ocrManager: OCRManagerProtocol
+    private let cardPostProcessor: CardPostProcessorProtocol
     private let imagePrepareService: ImagePrepareServiceProtocol
     private var editedImage: UIImage?
     private var imageSourceData: ImageSourceData?
@@ -68,18 +68,18 @@ final class CardInfoViewModel: BaseViewModelProtocol {
         let shouldPopToListOnDelete: Driver<Bool>
     }
 
-    init(editedImage: UIImage?, realmManager: RealmManagerProtocol = RealmManager.shared, ocrManager: OCRManagerProtocol = OCRManager.shared, imagePrepareService: ImagePrepareServiceProtocol = ImagePrepareService()) {
+    init(editedImage: UIImage?, realmManager: RealmManagerProtocol = RealmManager.shared, cardPostProcessor: CardPostProcessorProtocol = CardPostProcessor.shared, imagePrepareService: ImagePrepareServiceProtocol = ImagePrepareService()) {
         self.realmManager = realmManager
-        self.ocrManager = ocrManager
+        self.cardPostProcessor = cardPostProcessor
         self.imagePrepareService = imagePrepareService
         self.editedImage = editedImage
         self.cardToEditId = nil
         self.sourceType = nil
     }
 
-    init(initialDate: Date, sourceType: EditSourceType, realmManager: RealmManagerProtocol = RealmManager.shared, ocrManager: OCRManagerProtocol = OCRManager.shared, imagePrepareService: ImagePrepareServiceProtocol = ImagePrepareService()) {
+    init(initialDate: Date, sourceType: EditSourceType, realmManager: RealmManagerProtocol = RealmManager.shared, cardPostProcessor: CardPostProcessorProtocol = CardPostProcessor.shared, imagePrepareService: ImagePrepareServiceProtocol = ImagePrepareService()) {
         self.realmManager = realmManager
-        self.ocrManager = ocrManager
+        self.cardPostProcessor = cardPostProcessor
         self.imagePrepareService = imagePrepareService
         self.editedImage = nil
         self.cardToEditId = nil
@@ -108,9 +108,9 @@ final class CardInfoViewModel: BaseViewModelProtocol {
         return ImageSourceData(image: editedImage, originalData: imageData, format: format)
     }
 
-    init(cardToEdit cardId: ObjectId, sourceType: EditSourceType, realmManager: RealmManagerProtocol = RealmManager.shared, ocrManager: OCRManagerProtocol = OCRManager.shared, imagePrepareService: ImagePrepareServiceProtocol = ImagePrepareService()) {
+    init(cardToEdit cardId: ObjectId, sourceType: EditSourceType, realmManager: RealmManagerProtocol = RealmManager.shared, cardPostProcessor: CardPostProcessorProtocol = CardPostProcessor.shared, imagePrepareService: ImagePrepareServiceProtocol = ImagePrepareService()) {
         self.realmManager = realmManager
-        self.ocrManager = ocrManager
+        self.cardPostProcessor = cardPostProcessor
         self.imagePrepareService = imagePrepareService
         self.cardToEditId = cardId
         self.sourceType = sourceType
@@ -376,32 +376,25 @@ final class CardInfoViewModel: BaseViewModelProtocol {
 
         let sanitized = sanitizeTextFields(memo: memo, customFolder: customFolder)
         let analyticsCtx = collectAnalyticsContext()
-        let stickers = imageSourceData?.stickers ?? []
 
-        Logger.database.info("Save: stickers=\(stickers.count)")
-
-        let imageData$ = prepareImage(from: editedImage)
-        let ocr$ = ocrManager.recognizeText(from: editedImage)
-
-        return Observable.zip(imageData$, ocr$)
+        return prepareImage(from: editedImage)
             .observe(on: MainScheduler.instance)
-            .flatMap { [weak self] imageData, ocrText -> Observable<Void> in
+            .flatMap { [weak self] imageData -> Observable<Void> in
                 guard let self = self else { return .empty() }
 
                 let card = self.createCard(
                     date: date,
                     imageData: imageData,
-                    ocrText: ocrText,
+                    ocrText: nil,
                     memo: sanitized.memo,
                     customFolder: sanitized.customFolder,
                     location: location,
                     isLocked: isLocked
                 )
 
-                Logger.database.notice("Saved card: stickers=\(stickers.count)")
-
                 return self.realmManager.add(card)
                     .do(onNext: {
+                        self.cardPostProcessor.process(cardId: card.id, imageData: imageData.editedImageData)
                         self.logSaveAnalytics(isFirstCard: analyticsCtx.isFirstCard, hadLocationBefore: analyticsCtx.hadLocationBefore, location: location)
                         WidgetDataManager.shared.refreshWidgetData()
                     })
@@ -568,28 +561,23 @@ final class CardInfoViewModel: BaseViewModelProtocol {
             })
         }
 
-        let stickers = imageSourceData?.stickers ?? []
-        Logger.database.info("Update: stickers=\(stickers.count)")
-
-        let imageData$ = prepareImage(from: editedImage)
-        let ocr$ = ocrManager.recognizeText(from: editedImage)
-
-        return Observable.zip(imageData$, ocr$)
+        return prepareImage(from: editedImage)
             .observe(on: MainScheduler.instance)
-            .flatMap { [weak self] imageData, ocrText -> Observable<Void> in
+            .flatMap { [weak self] imageData -> Observable<Void> in
                 guard let self = self else { return .empty() }
 
                 return self.updateCardInRealm(
                     cardId: cardId,
                     date: date,
                     imageData: imageData,
-                    ocrText: ocrText,
+                    ocrText: nil,
                     memoText: sanitizedFields.memo,
                     folderText: sanitizedFields.customFolder,
                     location: location,
                     isLocked: isLocked
                 )
                 .do(onNext: {
+                    self.cardPostProcessor.process(cardId: cardId, imageData: imageData.editedImageData)
                     self.logUpdateAnalytics(editTypes: editTypes, hadLocationBefore: analyticsCtx.hadLocationBefore, location: location)
                 })
             }
@@ -600,11 +588,12 @@ final class CardInfoViewModel: BaseViewModelProtocol {
         date: Date,
         imageData: PreparedImageData,
         ocrText: String?,
+        visionTags: [VisionTag],
         memoText: String?,
         folderText: String?,
         location: CLLocation?,
         isLocked: Bool
-    ) -> Observable<Void> {
+    ) -> Observable<(Void, ObjectId)> {
         let oldImagePath = realmManager.fetchObject(Card.self, forPrimaryKey: cardId)?.imagePath
 
         let newCard = createCard(
@@ -616,6 +605,8 @@ final class CardInfoViewModel: BaseViewModelProtocol {
             location: location,
             isLocked: isLocked
         )
+        newCard.visionTags.append(objectsIn: visionTags)
+        let newCardId = newCard.id
 
         Logger.database.notice("Replaced card")
 
@@ -625,7 +616,8 @@ final class CardInfoViewModel: BaseViewModelProtocol {
                 realm.delete(cardToDelete)
             }
         }
-        .do(onNext: {
+        .map { ((), newCardId) }
+        .do(onNext: { _ in
             if let oldPath = oldImagePath {
                 ImageFileManager.shared.deleteImageFile(at: oldPath)
             }
@@ -640,9 +632,6 @@ final class CardInfoViewModel: BaseViewModelProtocol {
 
         let sanitizedFields = sanitizeTextFields(memo: memo, customFolder: customFolder)
         let analyticsCtx = collectAnalyticsContext()
-        let stickers = imageSourceData?.stickers ?? []
-
-        Logger.database.info("Replace: stickers=\(stickers.count)")
 
         let oldLocation = (card.latitude != nil && card.longitude != nil) ? CLLocation(latitude: card.latitude!, longitude: card.longitude!) : nil
         let editTypes = trackEditTypes(
@@ -653,27 +642,32 @@ final class CardInfoViewModel: BaseViewModelProtocol {
             isLocked: isLocked
         )
 
-        let imageData$ = prepareImage(from: editedImage)
-        let ocr$ = imageChanged ? ocrManager.recognizeText(from: editedImage) : Observable.just(card.ocrText)
+        let existingOcrText = imageChanged ? nil : card.ocrText
+        let existingVisionTags = imageChanged ? [] : Array(card.visionTags)
 
-        return Observable.zip(imageData$, ocr$)
+        return prepareImage(from: editedImage)
             .observe(on: MainScheduler.instance)
-            .flatMap { [weak self] imageData, ocrText -> Observable<Void> in
+            .flatMap { [weak self] imageData -> Observable<Void> in
                 guard let self = self else { return .empty() }
 
                 return self.createNewCardAndReplaceOld(
                     cardId: cardId,
                     date: date,
                     imageData: imageData,
-                    ocrText: ocrText,
+                    ocrText: existingOcrText,
+                    visionTags: existingVisionTags,
                     memoText: sanitizedFields.memo,
                     folderText: sanitizedFields.customFolder,
                     location: location,
                     isLocked: isLocked
                 )
-                .do(onNext: {
+                .do(onNext: { _, newCardId in
+                    if self.imageChanged {
+                        self.cardPostProcessor.process(cardId: newCardId, imageData: imageData.editedImageData)
+                    }
                     self.logUpdateAnalytics(editTypes: editTypes, hadLocationBefore: analyticsCtx.hadLocationBefore, location: location)
                 })
+                .map { _, _ in () }
             }
     }
 }

--- a/Sahara/Feature/Gallery/Model/ThemeCategory.swift
+++ b/Sahara/Feature/Gallery/Model/ThemeCategory.swift
@@ -87,6 +87,27 @@ enum ThemeCategory: String, CaseIterable {
 
         return .others
     }
+
+    static func category(for tags: [VisionTag]) -> ThemeCategory {
+        let tagSet = Set(tags)
+
+        if !tagSet.isDisjoint(with: [.cat, .dog, .bird]) {
+            return .animals
+        }
+        if tagSet.contains(.person) {
+            return .people
+        }
+        if !tagSet.isDisjoint(with: [.food, .drink]) {
+            return .food
+        }
+        if !tagSet.isDisjoint(with: [.nature, .sky, .sunset, .flower, .tree, .ocean, .mountain]) {
+            return .nature
+        }
+        if !tagSet.isDisjoint(with: [.building, .landmark, .indoor, .outdoor]) {
+            return .buildings
+        }
+        return .others
+    }
 }
 
 import RealmSwift

--- a/Sahara/Feature/Gallery/Tab/Theme/ThemeViewModel.swift
+++ b/Sahara/Feature/Gallery/Tab/Theme/ThemeViewModel.swift
@@ -70,9 +70,13 @@ final class ThemeViewModel: BaseViewModelProtocol {
 
         return realmManager.observeAllCards()
             .map { cards in
-                cards.compactMap { card -> (id: ObjectId, imageData: Data)? in
+                cards.compactMap { card -> (id: ObjectId, visionTags: [VisionTag], imageData: Data?)? in
+                    let tags = Array(card.visionTags)
+                    if !tags.isEmpty {
+                        return (id: card.id, visionTags: tags, imageData: nil)
+                    }
                     guard let data = card.resolvedImageData() else { return nil }
-                    return (id: card.id, imageData: data)
+                    return (id: card.id, visionTags: [], imageData: data)
                 }
             }
             .observe(on: backgroundScheduler)
@@ -81,10 +85,14 @@ final class ThemeViewModel: BaseViewModelProtocol {
                 var categoryDict: [ThemeCategory: [ObjectId]] = [:]
 
                 for item in items {
-                    guard let image = ImageDownsampler.downsample(data: item.imageData, maxDimension: 500),
-                          let cgImage = image.cgImage else { continue }
-
-                    let category = self.classifyImage(cgImage)
+                    let category: ThemeCategory
+                    if !item.visionTags.isEmpty {
+                        category = ThemeCategory.category(for: item.visionTags)
+                    } else if let imageData = item.imageData {
+                        category = self.classifyImage(from: imageData)
+                    } else {
+                        continue
+                    }
                     categoryDict[category, default: []].append(item.id)
                 }
 
@@ -101,20 +109,21 @@ final class ThemeViewModel: BaseViewModelProtocol {
             }
     }
 
+    private func classifyImage(from imageData: Data) -> ThemeCategory {
+        guard let image = ImageDownsampler.downsample(data: imageData, maxDimension: 500),
+              let cgImage = image.cgImage else {
+            return .others
+        }
 
-    private func classifyImage(_ cgImage: CGImage) -> ThemeCategory {
         let request = VNClassifyImageRequest()
-
         let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
         do {
             try handler.perform([request])
-
             if let observations = request.results {
                 let topLabels = observations.prefix(5).map { $0.identifier }
                 return ThemeCategory.category(for: topLabels)
             }
-        } catch {
-        }
+        } catch {}
 
         return .others
     }

--- a/Sahara/SceneDelegate.swift
+++ b/Sahara/SceneDelegate.swift
@@ -169,8 +169,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func sceneDidBecomeActive(_ scene: UIScene) {
-        // Called when the scene has moved from an inactive state to an active state.
-        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+        CardPostProcessor.shared.processUntaggedCards()
     }
 
     func sceneWillResignActive(_ scene: UIScene) {

--- a/SaharaTests/CardInfoViewModelTests.swift
+++ b/SaharaTests/CardInfoViewModelTests.swift
@@ -13,20 +13,20 @@ import XCTest
 final class CardInfoViewModelTests: XCTestCase {
     var sut: CardInfoViewModel!
     var mockRealmManager: MockRealmManager!
-    var mockOCRManager: MockOCRManager!
+    var mockCardPostProcessor: MockCardPostProcessor!
     var disposeBag: DisposeBag!
 
     override func setUp() {
         super.setUp()
         disposeBag = DisposeBag()
         mockRealmManager = MockRealmManager()
-        mockOCRManager = MockOCRManager()
+        mockCardPostProcessor = MockCardPostProcessor()
     }
 
     override func tearDown() {
         sut = nil
         mockRealmManager = nil
-        mockOCRManager = nil
+        mockCardPostProcessor = nil
         disposeBag = nil
         super.tearDown()
     }
@@ -45,8 +45,7 @@ final class CardInfoViewModelTests: XCTestCase {
 
     func test_saveWithImage_shouldCallRealmManagerAdd() {
         let testImage = createTestImage()
-        mockOCRManager.mockOCRText = "Test OCR text"
-        sut = CardInfoViewModel(editedImage: testImage, realmManager: mockRealmManager, ocrManager: mockOCRManager)
+        sut = CardInfoViewModel(editedImage: testImage, realmManager: mockRealmManager, cardPostProcessor: mockCardPostProcessor)
 
         let saveButtonTapped = PublishSubject<Void>()
 
@@ -82,7 +81,7 @@ final class CardInfoViewModelTests: XCTestCase {
     }
 
     func test_cancelButton_shouldEmitDismiss() {
-        sut = CardInfoViewModel(editedImage: nil, realmManager: mockRealmManager, ocrManager: mockOCRManager)
+        sut = CardInfoViewModel(editedImage: nil, realmManager: mockRealmManager, cardPostProcessor: mockCardPostProcessor)
 
         let cancelButtonTapped = PublishSubject<Void>()
 
@@ -115,7 +114,7 @@ final class CardInfoViewModelTests: XCTestCase {
     }
 
     func test_selectedImage_shouldUpdateHasImage() {
-        sut = CardInfoViewModel(editedImage: nil, realmManager: mockRealmManager, ocrManager: mockOCRManager)
+        sut = CardInfoViewModel(editedImage: nil, realmManager: mockRealmManager, cardPostProcessor: mockCardPostProcessor)
 
         let selectedImage = BehaviorSubject<UIImage?>(value: nil)
 
@@ -150,8 +149,47 @@ final class CardInfoViewModelTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
+    func test_saveWithImage_shouldTriggerPostProcessing() {
+        let testImage = createTestImage()
+        sut = CardInfoViewModel(editedImage: testImage, realmManager: mockRealmManager, cardPostProcessor: mockCardPostProcessor)
+
+        let saveButtonTapped = PublishSubject<Void>()
+
+        let input = CardInfoViewModel.Input(
+            selectedImage: .just(testImage),
+            imageSourceData: .just(nil),
+            date: .just(Date()),
+            memo: .just("Test memo"),
+            customFolder: .just(nil),
+            location: .empty(),
+            isLocked: .just(false),
+            saveButtonTapped: saveButtonTapped.asObservable(),
+            cancelButtonTapped: .empty(),
+            deleteButtonTapped: .empty()
+        )
+
+        let output = sut.transform(input: input)
+
+        let expectation = XCTestExpectation(description: "Save completed")
+
+        output.saved
+            .drive(onNext: { success in
+                if success {
+                    expectation.fulfill()
+                }
+            })
+            .disposed(by: disposeBag)
+
+        saveButtonTapped.onNext(())
+
+        wait(for: [expectation], timeout: 2.0)
+        XCTAssertTrue(mockCardPostProcessor.processCalled)
+        XCTAssertNotNil(mockCardPostProcessor.processedCardId)
+        XCTAssertNotNil(mockCardPostProcessor.processedImageData)
+    }
+
     func test_isEditMode_shouldBeFalseForNewCard() {
-        sut = CardInfoViewModel(editedImage: nil, realmManager: mockRealmManager, ocrManager: mockOCRManager)
+        sut = CardInfoViewModel(editedImage: nil, realmManager: mockRealmManager, cardPostProcessor: mockCardPostProcessor)
 
         let output = sut.transform(input: CardInfoViewModel.Input(
             selectedImage: .empty(),

--- a/SaharaTests/CardPostProcessorTests.swift
+++ b/SaharaTests/CardPostProcessorTests.swift
@@ -1,0 +1,49 @@
+//
+//  CardPostProcessorTests.swift
+//  SaharaTests
+//
+//  Created by 금가경 on 3/13/26.
+//
+
+import XCTest
+@testable import Sahara
+
+final class CardPostProcessorTests: XCTestCase {
+    var sut: CardPostProcessor!
+
+    override func setUp() {
+        super.setUp()
+        sut = CardPostProcessor()
+    }
+
+    override func tearDown() {
+        sut = nil
+        super.tearDown()
+    }
+
+    // MARK: - mapLabelsToVisionTags
+
+    func test_mapLabelsToVisionTags_duplicatesRemoved() {
+        let result = sut.mapLabelsToVisionTags(["cat", "kitten", "feline"])
+        XCTAssertEqual(result, [.cat])
+    }
+
+    func test_mapLabelsToVisionTags_multipleDistinctTags() {
+        let result = sut.mapLabelsToVisionTags(["person", "cat", "outdoor"])
+        XCTAssertTrue(result.contains(.person))
+        XCTAssertTrue(result.contains(.cat))
+        XCTAssertTrue(result.contains(.outdoor))
+        XCTAssertEqual(result.count, 3)
+    }
+
+    func test_mapLabelsToVisionTags_emptyInput_returnsEmpty() {
+        let result = sut.mapLabelsToVisionTags([])
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func test_mapLabelsToVisionTags_caseInsensitive() {
+        let result = sut.mapLabelsToVisionTags(["PERSON", "Cat"])
+        XCTAssertTrue(result.contains(.person))
+        XCTAssertTrue(result.contains(.cat))
+    }
+}

--- a/SaharaTests/Mocks/MockCardPostProcessor.swift
+++ b/SaharaTests/Mocks/MockCardPostProcessor.swift
@@ -1,0 +1,34 @@
+//
+//  MockCardPostProcessor.swift
+//  SaharaTests
+//
+//  Created by 금가경 on 3/13/26.
+//
+
+import Foundation
+import RealmSwift
+@testable import Sahara
+
+final class MockCardPostProcessor: CardPostProcessorProtocol {
+    var processCalled = false
+    var processedCardId: ObjectId?
+    var processedImageData: Data?
+    var processUntaggedCardsCalled = false
+
+    func process(cardId: ObjectId, imageData: Data) {
+        processCalled = true
+        processedCardId = cardId
+        processedImageData = imageData
+    }
+
+    func processUntaggedCards() {
+        processUntaggedCardsCalled = true
+    }
+
+    func reset() {
+        processCalled = false
+        processedCardId = nil
+        processedImageData = nil
+        processUntaggedCardsCalled = false
+    }
+}

--- a/SaharaTests/ThemeCategoryTests.swift
+++ b/SaharaTests/ThemeCategoryTests.swift
@@ -1,0 +1,36 @@
+//
+//  ThemeCategoryTests.swift
+//  SaharaTests
+//
+//  Created by 금가경 on 3/13/26.
+//
+
+import XCTest
+@testable import Sahara
+
+final class ThemeCategoryTests: XCTestCase {
+
+    // MARK: - category(for: [VisionTag]) — Priority Tests
+
+    func test_categoryForVisionTags_emptyArray_returnsOthers() {
+        let emptyTags: [VisionTag] = []
+        XCTAssertEqual(ThemeCategory.category(for: emptyTags), .others)
+    }
+
+    func test_categoryForVisionTags_mixedTags_animalsHasHighestPriority() {
+        XCTAssertEqual(ThemeCategory.category(for: [.person, .cat] as [VisionTag]), .animals)
+        XCTAssertEqual(ThemeCategory.category(for: [.food, .dog, .building] as [VisionTag]), .animals)
+    }
+
+    func test_categoryForVisionTags_mixedTags_peopleBeforeFood() {
+        XCTAssertEqual(ThemeCategory.category(for: [.person, .food] as [VisionTag]), .people)
+    }
+
+    func test_categoryForVisionTags_mixedTags_foodBeforeNature() {
+        XCTAssertEqual(ThemeCategory.category(for: [.food, .nature] as [VisionTag]), .food)
+    }
+
+    func test_categoryForVisionTags_mixedTags_natureBeforeBuildings() {
+        XCTAssertEqual(ThemeCategory.category(for: [.sky, .building] as [VisionTag]), .nature)
+    }
+}


### PR DESCRIPTION
Closes #57

## 변경 내용

**추가**
- 저장 완료 후 백그라운드에서 OCR/Vision 분류를 수행하는 후처리 매니저 추가
- 앱 활성화 시 태그가 없는 기존 카드를 자동으로 후처리
- 캐시된 Vision 태그를 활용한 테마 분류 경로 추가 (태그 없으면 기존 이미지 분류로 폴백)

**제거**
- 저장 체인 내 동기 OCR 호출 제거 (저장 속도 개선)

**수정**
- 카드 교체(replace) 시 기존 visionTags를 새 카드에 이관하도록 변경

## 결정 근거

- **비동기 후처리** — OCR/Vision이 저장을 블로킹하면 UX가 나빠지므로, 저장 완료 후 백그라운드에서 처리