### PR TITLE
Replace gradient sublayer with Auto Layout UIView and enable iPad multitasking

### DIFF
--- a/Sahara.xcodeproj/project.pbxproj
+++ b/Sahara.xcodeproj/project.pbxproj
@@ -567,9 +567,9 @@
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "카드를 만들기 위해 사진 라이브러리 접근 권한을 허용해주세요.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UIRequiresFullScreen = YES;
+				INFOPLIST_KEY_UIRequiresFullScreen = NO;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = UIInterfaceOrientationPortrait;
+				"INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad" = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
@@ -611,9 +611,9 @@
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "카드를 만들기 위해 사진 라이브러리 접근 권한을 허용해주세요.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UIRequiresFullScreen = YES;
+				INFOPLIST_KEY_UIRequiresFullScreen = NO;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = UIInterfaceOrientationPortrait;
+				"INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad" = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;

--- a/Sahara/Common/Component/CustomNavigationBar.swift
+++ b/Sahara/Common/Component/CustomNavigationBar.swift
@@ -49,15 +49,6 @@ final class CustomNavigationBar: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        if let gradientLayer = containerView.layer.sublayers?.first as? CAGradientLayer {
-            gradientLayer.frame = containerView.bounds
-        } else {
-            containerView.applyGradient(.tabBar)
-        }
-    }
-
     override func didMoveToWindow() {
         super.didMoveToWindow()
         enableSwipeBackGesture()
@@ -79,6 +70,7 @@ final class CustomNavigationBar: UIView {
         backgroundColor = .clear
 
         addSubview(containerView)
+        containerView.applyGradient(.tabBar)
         containerView.addSubview(leftButton)
         containerView.addSubview(titleLabel)
         containerView.addSubview(rightStackView)

--- a/Sahara/Common/Extension/UIView+Gradient.swift
+++ b/Sahara/Common/Extension/UIView+Gradient.swift
@@ -7,40 +7,52 @@
 
 import UIKit
 
-extension UIView {
-    func applyGradient(_ gradient: DesignToken.Gradient, removeExisting: Bool = false) {
-        if removeExisting {
-            layer.sublayers?.filter { $0 is CAGradientLayer }.forEach { $0.removeFromSuperlayer() }
-        }
+private final class GradientBackgroundView: UIView {
+    override class var layerClass: AnyClass { CAGradientLayer.self }
 
-        let gradientLayer = CAGradientLayer()
-        gradientLayer.frame = bounds
-        configureLayerForResizableWindow(gradientLayer)
-        gradientLayer.colors = gradient.colors
-        gradientLayer.locations = gradient.locations
-        gradientLayer.startPoint = gradient.startPoint
-        gradientLayer.endPoint = gradient.endPoint
-        layer.insertSublayer(gradientLayer, at: 0)
+    func configure(_ gradient: DesignToken.Gradient) {
+        let gl = layer as! CAGradientLayer
+        gl.colors = gradient.colors
+        gl.locations = gradient.locations
+        gl.startPoint = gradient.startPoint
+        gl.endPoint = gradient.endPoint
     }
+}
 
-    func applyDotPattern(dotSize: CGFloat, spacing: CGFloat, color: UIColor) {
+private final class DotPatternBackgroundView: UIView {
+    func configure(dotSize: CGFloat, spacing: CGFloat, color: UIColor) {
         let tileSize = CGSize(width: spacing, height: spacing)
         let renderer = UIGraphicsImageRenderer(size: tileSize)
         let patternImage = renderer.image { ctx in
             ctx.cgContext.setFillColor(color.cgColor)
             ctx.cgContext.fillEllipse(in: CGRect(x: 0, y: 0, width: dotSize, height: dotSize))
         }
-        let patternLayer = CALayer()
-        patternLayer.backgroundColor = UIColor(patternImage: patternImage).cgColor
-        patternLayer.frame = bounds
-        configureLayerForResizableWindow(patternLayer)
-        layer.insertSublayer(patternLayer, at: 1)
+        backgroundColor = UIColor(patternImage: patternImage)
+    }
+}
+
+extension UIView {
+    func applyGradient(_ gradient: DesignToken.Gradient, removeExisting: Bool = false) {
+        if let existing = subviews.first(where: { $0 is GradientBackgroundView }) as? GradientBackgroundView {
+            existing.configure(gradient)
+            return
+        }
+
+        let bgView = GradientBackgroundView()
+        bgView.configure(gradient)
+        bgView.isUserInteractionEnabled = false
+        insertSubview(bgView, at: 0)
+        bgView.snp.makeConstraints { $0.edges.equalToSuperview() }
     }
 
-    private func configureLayerForResizableWindow(_ layer: CALayer) {
-        #if targetEnvironment(macCatalyst)
-        layer.autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
-        #endif
+    func applyDotPattern(dotSize: CGFloat, spacing: CGFloat, color: UIColor) {
+        if subviews.contains(where: { $0 is DotPatternBackgroundView }) { return }
+
+        let bgView = DotPatternBackgroundView()
+        bgView.configure(dotSize: dotSize, spacing: spacing, color: color)
+        bgView.isUserInteractionEnabled = false
+        insertSubview(bgView, at: 1)
+        bgView.snp.makeConstraints { $0.edges.equalToSuperview() }
     }
 
     func applyGradientWithDots(_ gradient: DesignToken.Gradient, dotSize: CGFloat, spacing: CGFloat, dotColor: UIColor) {

--- a/Sahara/Feature/MediaEditor/MediaEditorViewController.swift
+++ b/Sahara/Feature/MediaEditor/MediaEditorViewController.swift
@@ -300,7 +300,6 @@ final class MediaEditorViewController: UIViewController {
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        toolBarContainer.layer.sublayers?.first(where: { $0 is CAGradientLayer })?.frame = toolBarContainer.bounds
         doneButton.applyGradient(.ctaPink)
         cropApplyButton.applyGradient(.ctaPink)
         updateStarPositions()

--- a/Sahara/Feature/Tab/MainTabBarController.swift
+++ b/Sahara/Feature/Tab/MainTabBarController.swift
@@ -128,11 +128,6 @@ final class MainTabBarController: UIViewController {
         }
     }
 
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-        customTabBar.layer.sublayers?.first(where: { $0 is CAGradientLayer })?.frame = customTabBar.bounds
-    }
-
     private func setupViewControllers() {
         let galleryVM = GalleryViewModel()
         let galleryVC = GalleryViewController(viewModel: galleryVM)


### PR DESCRIPTION
Closes #66

## 변경 내용

**수정**
- 배경 그라데이션을 sublayer에서 UIView 서브뷰 + Auto Layout 방식으로 전환
- 도트 패턴 배경도 동일하게 UIView 서브뷰 방식으로 전환
- iPad 방향 설정을 전 방향으로 변경하고 멀티태스킹(Split View/Slide Over) 활성화

**제거**
- macCatalyst 전용 레이어 리사이즈 분기
- 네비게이션 바, 탭 바, 미디어 에디터의 수동 sublayer frame 갱신 코드

## 결정 근거

- **UIView + Auto Layout** — sublayer는 Auto Layout을 지원하지 않아 수동 frame 갱신이 필요하지만, 뷰 자체를 그라데이션 레이어로 만들면 Auto Layout이 자동으로 크기를 관리하여 플랫폼 분기 없이 통일 가능
- **UIRequiresFullScreen = NO** — iPad 멀티태스킹 지원 및 App Store 심사 요건 충족을 위해 전 방향 지원과 함께 변경