### PR TITLE
Add iPad sidebar navigation

### DIFF
--- a/Sahara.xcodeproj/project.pbxproj
+++ b/Sahara.xcodeproj/project.pbxproj
@@ -569,7 +569,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIRequiresFullScreen = NO;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
-				"INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad" = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
@@ -613,7 +613,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIRequiresFullScreen = NO;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
-				"INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad" = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;

--- a/Sahara/Common/Component/CustomNavigationBar.swift
+++ b/Sahara/Common/Component/CustomNavigationBar.swift
@@ -136,6 +136,10 @@ final class CustomNavigationBar: UIView {
         leftButton.isHidden = true
     }
 
+    func showLeftButton() {
+        leftButton.isHidden = false
+    }
+
     func setLeftButtonImage(_ image: UIImage?) {
         var config = leftButton.configuration
         config?.image = image

--- a/Sahara/Common/Design/DesignToken+Gradient.swift
+++ b/Sahara/Common/Design/DesignToken+Gradient.swift
@@ -12,6 +12,7 @@ extension DesignToken {
     enum Gradient {
         case primary
         case tabBar
+        case sidebar
         case ctaPink
         case ctaBlue
         case subtle
@@ -29,8 +30,13 @@ extension DesignToken {
                 ]
             case .tabBar:
                 return [
-                    UIColor(hex: "#E8EAFF").cgColor,
-                    UIColor(hex: "#BDBCBD").cgColor
+                    UIColor(hex: "#F3F2FF").cgColor,
+                    UIColor(hex: "#D2D1EC").cgColor
+                ]
+            case .sidebar:
+                return [
+                    UIColor(hex: "#F3F2FF").cgColor,
+                    UIColor(hex: "#D2D1EC").cgColor
                 ]
             case .ctaPink:
                 return [
@@ -70,7 +76,7 @@ extension DesignToken {
             switch self {
             case .primary, .warm:
                 return [0.0, 0.5, 1.0]
-            case .tabBar:
+            case .tabBar, .sidebar:
                 return [0.22, 1.0]
             case .ctaPink, .ctaBlue, .subtle, .fresh, .highlight:
                 return [0.0, 1.0]
@@ -78,11 +84,21 @@ extension DesignToken {
         }
 
         var startPoint: CGPoint {
-            CGPoint(x: 0.5, y: 0.0)
+            switch self {
+            case .sidebar:
+                return CGPoint(x: 1.0, y: 0.5)
+            default:
+                return CGPoint(x: 0.5, y: 0.0)
+            }
         }
 
         var endPoint: CGPoint {
-            CGPoint(x: 0.5, y: 1.0)
+            switch self {
+            case .sidebar:
+                return CGPoint(x: 0.0, y: 0.5)
+            default:
+                return CGPoint(x: 0.5, y: 1.0)
+            }
         }
     }
 }

--- a/Sahara/Common/Layout/CalendarLayout.swift
+++ b/Sahara/Common/Layout/CalendarLayout.swift
@@ -1,0 +1,41 @@
+//
+//  CalendarLayout.swift
+//  Sahara
+//
+//  Created by 금가경 on 3/16/26.
+//
+
+import UIKit
+
+final class CalendarLayout: UICollectionViewFlowLayout {
+    override init() {
+        super.init()
+        minimumInteritemSpacing = 1
+        minimumLineSpacing = 1
+        sectionInset = .zero
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func prepare() {
+        super.prepare()
+        guard let collectionView = collectionView else { return }
+
+        let headerHeight: CGFloat = 72
+        headerReferenceSize = CGSize(width: collectionView.bounds.width, height: headerHeight)
+
+        let width = collectionView.bounds.width
+        let itemWidth = ((width - 6) / 7).rounded(.down)
+        let height = collectionView.bounds.height - headerHeight
+        let itemHeight = ((height - 5) / 6).rounded(.down)
+
+        itemSize = CGSize(width: itemWidth, height: itemHeight)
+    }
+
+    override func shouldInvalidateLayout(forBoundsChange newBounds: CGRect) -> Bool {
+        guard let collectionView = collectionView else { return false }
+        return newBounds.size != collectionView.bounds.size
+    }
+}

--- a/Sahara/Feature/Gallery/GalleryViewController.swift
+++ b/Sahara/Feature/Gallery/GalleryViewController.swift
@@ -136,7 +136,7 @@ final class GalleryViewController: UIViewController {
 
     private func setupCustomNavigationBar() {
         customNavigationBar.configure(title: NSLocalizedString("common.app_name", comment: ""))
-        customNavigationBar.hideLeftButton()
+        updateLeftButtonForCurrentMode()
 
         customNavigationBar.addRightButton(title: "+") { [weak self] in
             self?.addButtonTapped()
@@ -240,25 +240,25 @@ final class GalleryViewController: UIViewController {
         calendarContainerView.snp.makeConstraints { make in
             make.top.equalTo(viewTypeButtonStackView.snp.bottom).offset(20)
             make.horizontalEdges.equalToSuperview().inset(20)
-            make.bottom.equalToSuperview().inset(112)
+            make.bottom.equalTo(view.safeAreaLayoutGuide)
         }
 
         mapView.snp.makeConstraints { make in
             make.top.equalTo(viewTypeButtonStackView.snp.bottom).offset(20)
             make.horizontalEdges.equalToSuperview().inset(20)
-            make.bottom.equalToSuperview().inset(112)
+            make.bottom.equalTo(view.safeAreaLayoutGuide)
         }
 
         themeContainerView.snp.makeConstraints { make in
             make.top.equalTo(viewTypeButtonStackView.snp.bottom).offset(20)
             make.horizontalEdges.equalToSuperview().inset(20)
-            make.bottom.equalToSuperview().inset(112)
+            make.bottom.equalTo(view.safeAreaLayoutGuide)
         }
 
         folderContainerView.snp.makeConstraints { make in
             make.top.equalTo(viewTypeButtonStackView.snp.bottom).offset(20)
             make.horizontalEdges.equalToSuperview().inset(20)
-            make.bottom.equalToSuperview().inset(112)
+            make.bottom.equalTo(view.safeAreaLayoutGuide)
         }
 
     }
@@ -463,4 +463,23 @@ extension GalleryViewController: MKMapViewDelegate {
         navigationController?.pushViewController(galleryVC, animated: true)
     }
 
+    private func updateLeftButtonForCurrentMode() {
+        if let toggler = navigationController?.parent as? SidebarToggleable, toggler.isSidebarMode {
+            customNavigationBar.showLeftButton()
+            customNavigationBar.setLeftButtonImage(UIImage(systemName: "sidebar.leading"))
+            customNavigationBar.onLeftButtonTapped = { [weak toggler] in
+                toggler?.toggleSidebar()
+            }
+        } else {
+            customNavigationBar.hideLeftButton()
+        }
+    }
+}
+
+// MARK: - SidebarModeObserver
+
+extension GalleryViewController: SidebarModeObserver {
+    func sidebarModeDidChange() {
+        updateLeftButtonForCurrentMode()
+    }
 }

--- a/Sahara/Feature/Search/SearchViewController.swift
+++ b/Sahara/Feature/Search/SearchViewController.swift
@@ -67,7 +67,19 @@ final class SearchViewController: UIViewController {
 
     private func setupCustomNavigationBar() {
         customNavigationBar.configure(title: NSLocalizedString("tab.search", comment: ""))
-        customNavigationBar.hideLeftButton()
+        updateLeftButtonForCurrentMode()
+    }
+
+    private func updateLeftButtonForCurrentMode() {
+        if let toggler = navigationController?.parent as? SidebarToggleable, toggler.isSidebarMode {
+            customNavigationBar.showLeftButton()
+            customNavigationBar.setLeftButtonImage(UIImage(systemName: "sidebar.leading"))
+            customNavigationBar.onLeftButtonTapped = { [weak toggler] in
+                toggler?.toggleSidebar()
+            }
+        } else {
+            customNavigationBar.hideLeftButton()
+        }
     }
 
     private func setupKeyboardDismiss() {
@@ -103,7 +115,7 @@ final class SearchViewController: UIViewController {
         collectionView.snp.makeConstraints { make in
             make.top.equalTo(searchBar.snp.bottom).offset(16)
             make.horizontalEdges.equalToSuperview().inset(24)
-            make.bottom.equalToSuperview().inset(90)
+            make.bottom.equalTo(view.safeAreaLayoutGuide)
         }
 
         emptyStateLabel.snp.makeConstraints { make in
@@ -192,5 +204,13 @@ extension SearchViewController: PinterestLayoutDelegate {
         let aspectRatio = size.height / size.width
         let cellWidth = collectionView.bounds.width / CGFloat(pinterestLayout.columnCount) - 8
         return cellWidth * aspectRatio
+    }
+}
+
+// MARK: - SidebarModeObserver
+
+extension SearchViewController: SidebarModeObserver {
+    func sidebarModeDidChange() {
+        updateLeftButtonForCurrentMode()
     }
 }

--- a/Sahara/Feature/Settings/SettingsViewController.swift
+++ b/Sahara/Feature/Settings/SettingsViewController.swift
@@ -61,7 +61,19 @@ final class SettingsViewController: UIViewController {
 
     private func setupCustomNavigationBar() {
         customNavigationBar.configure(title: NSLocalizedString("settings.title", comment: ""))
-        customNavigationBar.hideLeftButton()
+        updateLeftButtonForCurrentMode()
+    }
+
+    private func updateLeftButtonForCurrentMode() {
+        if let toggler = navigationController?.parent as? SidebarToggleable, toggler.isSidebarMode {
+            customNavigationBar.showLeftButton()
+            customNavigationBar.setLeftButtonImage(UIImage(systemName: "sidebar.leading"))
+            customNavigationBar.onLeftButtonTapped = { [weak toggler] in
+                toggler?.toggleSidebar()
+            }
+        } else {
+            customNavigationBar.hideLeftButton()
+        }
     }
 
     private func configureUI() {
@@ -459,5 +471,13 @@ extension UIAlertController {
             make.bottom.equalToSuperview().inset(45)
         }
         return (alert, progressView)
+    }
+}
+
+// MARK: - SidebarModeObserver
+
+extension SettingsViewController: SidebarModeObserver {
+    func sidebarModeDidChange() {
+        updateLeftButtonForCurrentMode()
     }
 }

--- a/Sahara/Feature/Stats/StatsViewController.swift
+++ b/Sahara/Feature/Stats/StatsViewController.swift
@@ -134,7 +134,19 @@ final class StatsViewController: UIViewController {
 
     private func setupCustomNavigationBar() {
         customNavigationBar.configure(title: NSLocalizedString("stats.title", comment: ""))
-        customNavigationBar.hideLeftButton()
+        updateLeftButtonForCurrentMode()
+    }
+
+    private func updateLeftButtonForCurrentMode() {
+        if let toggler = navigationController?.parent as? SidebarToggleable, toggler.isSidebarMode {
+            customNavigationBar.showLeftButton()
+            customNavigationBar.setLeftButtonImage(UIImage(systemName: "sidebar.leading"))
+            customNavigationBar.onLeftButtonTapped = { [weak toggler] in
+                toggler?.toggleSidebar()
+            }
+        } else {
+            customNavigationBar.hideLeftButton()
+        }
     }
 
     private func configureUI() {
@@ -175,7 +187,7 @@ final class StatsViewController: UIViewController {
         scrollView.snp.makeConstraints { make in
             make.top.equalTo(customNavigationBar.snp.bottom)
             make.horizontalEdges.equalToSuperview()
-            make.bottom.equalToSuperview().inset(90)
+            make.bottom.equalTo(view.safeAreaLayoutGuide)
         }
 
         contentStackView.snp.makeConstraints { make in
@@ -281,6 +293,14 @@ final class StatsViewController: UIViewController {
 //                owner.moodChartView.configure(labels: labels, values: values)
 //            }
 //            .disposed(by: disposeBag)
+    }
+}
+
+// MARK: - SidebarModeObserver
+
+extension StatsViewController: SidebarModeObserver {
+    func sidebarModeDidChange() {
+        updateLeftButtonForCurrentMode()
     }
 }
 

--- a/Sahara/Feature/Tab/MainTabBarController.swift
+++ b/Sahara/Feature/Tab/MainTabBarController.swift
@@ -8,8 +8,25 @@
 import UIKit
 import SnapKit
 
-final class MainTabBarController: UIViewController {
+// MARK: - Protocols
+
+protocol SidebarToggleable: AnyObject {
+    var isSidebarMode: Bool { get }
+    func toggleSidebar()
+}
+
+protocol SidebarModeObserver: AnyObject {
+    func sidebarModeDidChange()
+}
+
+// MARK: - MainTabBarController
+
+final class MainTabBarController: UIViewController, SidebarToggleable {
+
+    // MARK: - Properties
+
     private var childNavigationControllers: [UINavigationController] = []
+    private let tabBarContentHeight: CGFloat = 60
 
     var selectedIndex: Int = 0 {
         didSet {
@@ -24,6 +41,22 @@ final class MainTabBarController: UIViewController {
         return childNavigationControllers[selectedIndex]
     }
 
+    // MARK: - Sidebar State
+
+    private(set) var isSidebarMode = false
+    private var isSidebarExpanded = true
+
+    private var shouldShowSidebar: Bool {
+        #if targetEnvironment(macCatalyst)
+        return true
+        #else
+        return traitCollection.userInterfaceIdiom == .pad
+            && traitCollection.horizontalSizeClass == .regular
+        #endif
+    }
+
+    // MARK: - Tab Bar UI
+
     private let customTabBar: UIView = {
         let view = UIView()
         return view
@@ -37,82 +70,78 @@ final class MainTabBarController: UIViewController {
         return stack
     }()
 
-    private lazy var galleryTabButton: TabButton = {
-        let button = TabButton(
-            icon: UIImage(named: "gallery"),
-            title: NSLocalizedString("tab.gallery", comment: "")
-        )
-        button.onTap = { [weak self] in
-            self?.galleryTabTapped()
+    private var tabBarButtons: [TabItem: TabButton] = [:]
+
+    // MARK: - Sidebar UI
+
+    private lazy var sidebarView: SidebarView = {
+        let sidebar = SidebarView()
+        sidebar.onTabSelected = { [weak self] item in
+            self?.tabSelected(item)
         }
-        return button
+        return sidebar
     }()
 
-    private lazy var searchTabButton: TabButton = {
-        let button = TabButton(
-            icon: UIImage(systemName: "magnifyingglass"),
-            title: NSLocalizedString("tab.search", comment: "")
-        )
-        button.onTap = { [weak self] in
-            self?.searchTabTapped()
-        }
-        return button
-    }()
+    private var sidebarWidthConstraint: Constraint?
 
-    private lazy var statsTabButton: TabButton = {
-        let button = TabButton(
-            icon: UIImage(systemName: "chart.bar.fill"),
-            title: NSLocalizedString("tab.stats", comment: "")
-        )
-        button.onTap = { [weak self] in
-            self?.statsTabTapped()
-        }
-        return button
-    }()
-
-    private lazy var settingsTabButton: TabButton = {
-        let button = TabButton(
-            icon: UIImage(systemName: "gearshape.fill"),
-            title: NSLocalizedString("tab.settings", comment: "")
-        )
-        button.onTap = { [weak self] in
-            self?.settingsTabTapped()
-        }
-        return button
-    }()
+    // MARK: - Lifecycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        setupCustomTabBar()
+        setupNavigationUI()
         setupViewControllers()
     }
 
-    private func setupCustomTabBar() {
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        guard previousTraitCollection?.horizontalSizeClass != traitCollection.horizontalSizeClass else { return }
+        transitionNavigationUI()
+    }
+
+    // MARK: - Navigation UI
+
+    private func setupNavigationUI() {
+        if shouldShowSidebar {
+            installSidebar()
+        } else {
+            installTabBar()
+        }
+    }
+
+    private func transitionNavigationUI() {
+        if shouldShowSidebar && !isSidebarMode {
+            removeTabBar()
+            installSidebar()
+            relayoutCurrentChild()
+        } else if !shouldShowSidebar && isSidebarMode {
+            removeSidebar()
+            installTabBar()
+            relayoutCurrentChild()
+        }
+        notifyChildrenOfModeChange()
+    }
+
+    // MARK: - Tab Bar
+
+    private func installTabBar() {
+        isSidebarMode = false
+
         view.addSubview(customTabBar)
         customTabBar.addSubview(tabButtonStackView)
 
-        tabButtonStackView.addArrangedSubview(galleryTabButton)
-        tabButtonStackView.addArrangedSubview(searchTabButton)
-        tabButtonStackView.addArrangedSubview(statsTabButton)
-        tabButtonStackView.addArrangedSubview(settingsTabButton)
+        for item in TabItem.allCases {
+            let button = TabButton(icon: item.icon, title: item.title)
+            button.onTap = { [weak self] in
+                self?.tabSelected(item)
+            }
+            button.snp.makeConstraints { make in
+                make.width.height.equalTo(44)
+            }
+            tabButtonStackView.addArrangedSubview(button)
+            tabBarButtons[item] = button
+        }
 
         customTabBar.applyGradient(.tabBar)
-
-        galleryTabButton.snp.makeConstraints { make in
-            make.width.height.equalTo(44)
-        }
-
-        searchTabButton.snp.makeConstraints { make in
-            make.width.height.equalTo(44)
-        }
-
-        statsTabButton.snp.makeConstraints { make in
-            make.width.height.equalTo(44)
-        }
-
-        settingsTabButton.snp.makeConstraints { make in
-            make.width.height.equalTo(44)
-        }
 
         tabButtonStackView.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
@@ -126,7 +155,56 @@ final class MainTabBarController: UIViewController {
             make.bottom.equalToSuperview()
             make.top.equalTo(tabButtonStackView.snp.top).offset(-8)
         }
+
+        updateTabSelection()
+        updateChildSafeAreaInsets()
     }
+
+    private func removeTabBar() {
+        tabButtonStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        tabBarButtons.removeAll()
+        customTabBar.removeFromSuperview()
+    }
+
+    // MARK: - Sidebar
+
+    private func installSidebar() {
+        isSidebarMode = true
+        isSidebarExpanded = true
+
+        view.addSubview(sidebarView)
+        sidebarView.alpha = 1
+
+        sidebarView.snp.makeConstraints { make in
+            make.top.bottom.leading.equalToSuperview()
+            sidebarWidthConstraint = make.width.equalTo(SidebarView.width).constraint
+        }
+
+        sidebarView.setSelectedTab(TabItem(rawValue: selectedIndex) ?? .gallery)
+        updateChildSafeAreaInsets()
+    }
+
+    private func removeSidebar() {
+        sidebarView.removeFromSuperview()
+        sidebarWidthConstraint = nil
+        isSidebarMode = false
+    }
+
+    // MARK: - SidebarToggleable
+
+    func toggleSidebar() {
+        isSidebarExpanded.toggle()
+        let targetWidth: CGFloat = isSidebarExpanded ? SidebarView.width : 0
+
+        sidebarWidthConstraint?.update(offset: targetWidth)
+
+        UIView.animate(withDuration: 0.25, delay: 0, options: .curveEaseInOut) {
+            self.sidebarView.alpha = self.isSidebarExpanded ? 1 : 0
+            self.view.layoutIfNeeded()
+        }
+    }
+
+    // MARK: - Child VC Management
 
     private func setupViewControllers() {
         let galleryVM = GalleryViewModel()
@@ -145,13 +223,7 @@ final class MainTabBarController: UIViewController {
 
         childNavigationControllers = [galleryNav, searchNav, statsNav, settingsNav]
 
-        let firstNav = childNavigationControllers[0]
-        addChild(firstNav)
-        view.insertSubview(firstNav.view, belowSubview: customTabBar)
-        firstNav.view.frame = view.bounds
-        firstNav.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        firstNav.didMove(toParent: self)
-
+        embedChild(childNavigationControllers[0])
         updateTabSelection()
     }
 
@@ -162,39 +234,89 @@ final class MainTabBarController: UIViewController {
         fromNav.removeFromParent()
 
         let toNav = childNavigationControllers[newIndex]
-        addChild(toNav)
-        view.insertSubview(toNav.view, belowSubview: customTabBar)
-        toNav.view.frame = view.bounds
-        toNav.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        toNav.didMove(toParent: self)
+        embedChild(toNav)
 
         updateTabSelection()
     }
 
-    @objc private func galleryTabTapped() {
-        selectedIndex = 0
-        AnalyticsService.shared.logTabSelected(tabName: "gallery")
+    private func embedChild(_ childNav: UINavigationController) {
+        addChild(childNav)
+
+        if isSidebarMode {
+            view.insertSubview(childNav.view, belowSubview: sidebarView)
+        } else {
+            view.insertSubview(childNav.view, belowSubview: customTabBar)
+        }
+
+        childNav.view.translatesAutoresizingMaskIntoConstraints = false
+        childNav.view.snp.makeConstraints { make in
+            if isSidebarMode {
+                make.leading.equalTo(sidebarView.snp.trailing)
+            } else {
+                make.leading.equalToSuperview()
+            }
+            make.top.trailing.bottom.equalToSuperview()
+        }
+
+        childNav.didMove(toParent: self)
+        updateChildSafeAreaInsets()
     }
 
-    @objc private func searchTabTapped() {
-        selectedIndex = 1
-        AnalyticsService.shared.logTabSelected(tabName: "search")
+    private func relayoutCurrentChild() {
+        guard selectedIndex < childNavigationControllers.count else { return }
+        let currentNav = childNavigationControllers[selectedIndex]
+
+        currentNav.view.snp.remakeConstraints { make in
+            if isSidebarMode {
+                make.leading.equalTo(sidebarView.snp.trailing)
+            } else {
+                make.leading.equalToSuperview()
+            }
+            make.top.trailing.bottom.equalToSuperview()
+        }
+
+        if isSidebarMode {
+            view.insertSubview(currentNav.view, belowSubview: sidebarView)
+        } else {
+            view.insertSubview(currentNav.view, belowSubview: customTabBar)
+        }
+
+        updateChildSafeAreaInsets()
     }
 
-    @objc private func statsTabTapped() {
-        selectedIndex = 2
-        AnalyticsService.shared.logTabSelected(tabName: "stats")
+    private func updateChildSafeAreaInsets() {
+        let bottomInset: CGFloat = isSidebarMode ? 0 : tabBarContentHeight
+        for nav in childNavigationControllers {
+            nav.additionalSafeAreaInsets = UIEdgeInsets(
+                top: 0, left: 0, bottom: bottomInset, right: 0
+            )
+        }
     }
 
-    @objc private func settingsTabTapped() {
-        selectedIndex = 3
-        AnalyticsService.shared.logTabSelected(tabName: "settings")
+    // MARK: - Tab Selection
+
+    private func tabSelected(_ item: TabItem) {
+        selectedIndex = item.rawValue
+        AnalyticsService.shared.logTabSelected(tabName: item.analyticsName)
     }
 
     private func updateTabSelection() {
-        galleryTabButton.setSelected(selectedIndex == 0)
-        searchTabButton.setSelected(selectedIndex == 1)
-        statsTabButton.setSelected(selectedIndex == 2)
-        settingsTabButton.setSelected(selectedIndex == 3)
+        let selected = TabItem(rawValue: selectedIndex) ?? .gallery
+
+        for (item, button) in tabBarButtons {
+            button.setSelected(item == selected)
+        }
+
+        if isSidebarMode {
+            sidebarView.setSelectedTab(selected)
+        }
+    }
+
+    // MARK: - Notify Children
+
+    private func notifyChildrenOfModeChange() {
+        for nav in childNavigationControllers {
+            (nav.viewControllers.first as? SidebarModeObserver)?.sidebarModeDidChange()
+        }
     }
 }

--- a/Sahara/Feature/Tab/SidebarView.swift
+++ b/Sahara/Feature/Tab/SidebarView.swift
@@ -1,0 +1,64 @@
+//
+//  SidebarView.swift
+//  Sahara
+//
+//  Created by 금가경 on 3/16/26.
+//
+
+import SnapKit
+import UIKit
+
+final class SidebarView: UIView {
+    static let width: CGFloat = 72
+
+    private let stackView: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.alignment = .center
+        stack.spacing = 8
+        return stack
+    }()
+
+    private var tabButtons: [TabItem: TabButton] = [:]
+
+    var onTabSelected: ((TabItem) -> Void)?
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupUI() {
+        clipsToBounds = true
+        applyGradient(.sidebar)
+
+        addSubview(stackView)
+
+        for item in TabItem.allCases {
+            let button = TabButton(icon: item.icon, title: item.title)
+            button.onTap = { [weak self] in
+                self?.onTabSelected?(item)
+            }
+            button.snp.makeConstraints { make in
+                make.width.height.equalTo(56)
+            }
+            stackView.addArrangedSubview(button)
+            tabButtons[item] = button
+        }
+
+        stackView.snp.makeConstraints { make in
+            make.top.equalTo(safeAreaLayoutGuide).offset(16)
+            make.centerX.equalToSuperview()
+        }
+    }
+
+    func setSelectedTab(_ tab: TabItem) {
+        for (item, button) in tabButtons {
+            button.setSelected(item == tab)
+        }
+    }
+}

--- a/Sahara/Feature/Tab/TabItem.swift
+++ b/Sahara/Feature/Tab/TabItem.swift
@@ -1,0 +1,42 @@
+//
+//  TabItem.swift
+//  Sahara
+//
+//  Created by 금가경 on 3/16/26.
+//
+
+import UIKit
+
+enum TabItem: Int, CaseIterable {
+    case gallery = 0
+    case search = 1
+    case stats = 2
+    case settings = 3
+
+    var icon: UIImage? {
+        switch self {
+        case .gallery: return UIImage(named: "gallery")
+        case .search: return UIImage(systemName: "magnifyingglass")
+        case .stats: return UIImage(systemName: "chart.bar.fill")
+        case .settings: return UIImage(systemName: "gearshape.fill")
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .gallery: return NSLocalizedString("tab.gallery", comment: "")
+        case .search: return NSLocalizedString("tab.search", comment: "")
+        case .stats: return NSLocalizedString("tab.stats", comment: "")
+        case .settings: return NSLocalizedString("tab.settings", comment: "")
+        }
+    }
+
+    var analyticsName: String {
+        switch self {
+        case .gallery: return "gallery"
+        case .search: return "search"
+        case .stats: return "stats"
+        case .settings: return "settings"
+        }
+    }
+}


### PR DESCRIPTION
Closes #68

## 변경 내용

**추가**
- iPad/Mac Catalyst에서 탭바 대신 사이드바 네비게이션 제공
- 탭/사이드바 공유 모델 및 사이드바 토글 기능
- bounds 변경에 대응하는 캘린더 레이아웃
- 사이드바 전용 그라디언트

**수정**
- 각 화면의 하단 여백을 safeArea 기반으로 전환
- size class 변경 시 탭바 ↔ 사이드바 자동 전환

## 결정 근거

- **safeArea 기반 여백** — 하드코딩된 bottom inset 대신 safeArea를 사용하여 탭바/사이드바 모드 모두에서 정확한 레이아웃 보장