### PR TITLE
Fix floating window layout alignment

### DIFF
--- a/Sahara/Common/Component/CustomNavigationBar.swift
+++ b/Sahara/Common/Component/CustomNavigationBar.swift
@@ -38,11 +38,19 @@ final class CustomNavigationBar: UIView {
         return stackView
     }()
 
+    let contentLeadingGuide = UILayoutGuide()
+
     var onLeftButtonTapped: (() -> Void)?
+    private var contentLeadingConstraint: Constraint?
+    private var titleCenterXConstraint: Constraint?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupUI()
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(floatingWindowStateChanged),
+            name: .floatingWindowStateDidChange, object: nil
+        )
     }
 
     required init?(coder: NSCoder) {
@@ -52,6 +60,19 @@ final class CustomNavigationBar: UIView {
     override func didMoveToWindow() {
         super.didMoveToWindow()
         enableSwipeBackGesture()
+        updateLeadingForWindowControls(isFloating: isInFloatingWindow)
+    }
+
+    @objc private func floatingWindowStateChanged() {
+        updateLeadingForWindowControls(isFloating: isInFloatingWindow)
+    }
+
+    private func updateLeadingForWindowControls(isFloating: Bool) {
+        // 76: macOS 윈도우 컨트롤(신호등) 너비 + 여백
+        let leading: CGFloat = isFloating ? 76 : 16
+        contentLeadingConstraint?.update(offset: leading)
+        let titleOffset: CGFloat = (leading - 16) / 2
+        titleCenterXConstraint?.update(offset: titleOffset)
     }
 
     private func enableSwipeBackGesture() {
@@ -69,6 +90,7 @@ final class CustomNavigationBar: UIView {
     private func setupUI() {
         backgroundColor = .clear
 
+        addLayoutGuide(contentLeadingGuide)
         addSubview(containerView)
         containerView.applyGradient(.tabBar)
         containerView.addSubview(leftButton)
@@ -79,14 +101,21 @@ final class CustomNavigationBar: UIView {
             make.edges.equalToSuperview()
         }
 
+        contentLeadingGuide.snp.makeConstraints { make in
+            contentLeadingConstraint = make.leading.equalToSuperview().offset(16).constraint
+            make.top.bottom.equalToSuperview()
+            make.width.equalTo(0)
+        }
+
         leftButton.snp.makeConstraints { make in
-            make.leading.equalToSuperview().offset(16)
+            make.leading.equalTo(contentLeadingGuide.snp.trailing)
             make.centerY.equalToSuperview()
             make.width.height.equalTo(44)
         }
 
         titleLabel.snp.makeConstraints { make in
-            make.center.equalToSuperview()
+            titleCenterXConstraint = make.centerX.equalToSuperview().constraint
+            make.centerY.equalToSuperview()
         }
 
         rightStackView.snp.makeConstraints { make in

--- a/Sahara/Common/Component/CustomNavigationBar.swift
+++ b/Sahara/Common/Component/CustomNavigationBar.swift
@@ -42,7 +42,6 @@ final class CustomNavigationBar: UIView {
 
     var onLeftButtonTapped: (() -> Void)?
     private var contentLeadingConstraint: Constraint?
-    private var titleCenterXConstraint: Constraint?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -71,8 +70,6 @@ final class CustomNavigationBar: UIView {
         // 76: macOS 윈도우 컨트롤(신호등) 너비 + 여백
         let leading: CGFloat = isFloating ? 76 : 16
         contentLeadingConstraint?.update(offset: leading)
-        let titleOffset: CGFloat = (leading - 16) / 2
-        titleCenterXConstraint?.update(offset: titleOffset)
     }
 
     private func enableSwipeBackGesture() {
@@ -114,8 +111,7 @@ final class CustomNavigationBar: UIView {
         }
 
         titleLabel.snp.makeConstraints { make in
-            titleCenterXConstraint = make.centerX.equalToSuperview().constraint
-            make.centerY.equalToSuperview()
+            make.center.equalToSuperview()
         }
 
         rightStackView.snp.makeConstraints { make in

--- a/Sahara/Common/Extension/UIView+FloatingWindow.swift
+++ b/Sahara/Common/Extension/UIView+FloatingWindow.swift
@@ -1,0 +1,21 @@
+//
+//  UIView+FloatingWindow.swift
+//  Sahara
+//
+//  Created by 금가경 on 3/17/26.
+//
+
+import UIKit
+
+extension UIView {
+    var isInFloatingWindow: Bool {
+        guard let window = window,
+              let screen = window.windowScene?.screen else { return false }
+        return window.frame.width < screen.bounds.width - 1
+            || window.frame.height < screen.bounds.height - 1
+    }
+}
+
+extension Notification.Name {
+    static let floatingWindowStateDidChange = Notification.Name("floatingWindowStateDidChange")
+}

--- a/Sahara/Feature/CardInfo/CardInfoViewController.swift
+++ b/Sahara/Feature/CardInfo/CardInfoViewController.swift
@@ -101,7 +101,7 @@ final class CardInfoViewController: UIViewController {
         view.addSubview(saveButton)
 
         cancelButton.snp.makeConstraints { make in
-            make.leading.equalTo(customNavigationBar).offset(16)
+            make.leading.equalTo(customNavigationBar.contentLeadingGuide.snp.trailing)
             make.centerY.equalTo(customNavigationBar)
             make.width.equalTo(48)
             make.height.equalTo(44)

--- a/Sahara/Feature/Gallery/CardList/CardListViewController.swift
+++ b/Sahara/Feature/Gallery/CardList/CardListViewController.swift
@@ -115,7 +115,7 @@ final class CardListViewController: UIViewController {
             view.addSubview(closeButton)
 
             closeButton.snp.makeConstraints { make in
-                make.leading.equalTo(customNavigationBar).offset(8)
+                make.leading.equalTo(customNavigationBar.contentLeadingGuide.snp.trailing)
                 make.centerY.equalTo(customNavigationBar)
                 make.width.equalTo(44)
                 make.height.equalTo(44)

--- a/Sahara/Feature/MediaEditor/MediaEditorViewController+UI.swift
+++ b/Sahara/Feature/MediaEditor/MediaEditorViewController+UI.swift
@@ -17,7 +17,7 @@ extension MediaEditorViewController {
         view.addSubview(doneButton)
 
         cancelButton.snp.makeConstraints { make in
-            make.leading.equalTo(customNavigationBar).offset(16)
+            make.leading.equalTo(customNavigationBar.contentLeadingGuide.snp.trailing)
             make.centerY.equalTo(customNavigationBar)
             make.width.equalTo(48)
             make.height.equalTo(44)

--- a/Sahara/Feature/Tab/MainTabBarController.swift
+++ b/Sahara/Feature/Tab/MainTabBarController.swift
@@ -45,6 +45,7 @@ final class MainTabBarController: UIViewController, SidebarToggleable {
 
     private(set) var isSidebarMode = false
     private var isSidebarExpanded = true
+    private var wasFloating: Bool?
 
     private var shouldShowSidebar: Bool {
         #if targetEnvironment(macCatalyst)
@@ -92,10 +93,29 @@ final class MainTabBarController: UIViewController, SidebarToggleable {
         setupViewControllers()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        checkFloatingWindowState()
+    }
+
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        coordinator.animate(alongsideTransition: nil) { _ in
+            self.checkFloatingWindowState()
+        }
+    }
+
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         guard previousTraitCollection?.horizontalSizeClass != traitCollection.horizontalSizeClass else { return }
         transitionNavigationUI()
+    }
+
+    private func checkFloatingWindowState() {
+        let floating = view.isInFloatingWindow
+        guard floating != wasFloating else { return }
+        wasFloating = floating
+        NotificationCenter.default.post(name: .floatingWindowStateDidChange, object: nil)
     }
 
     // MARK: - Navigation UI

--- a/Sahara/Feature/Tab/SidebarView.swift
+++ b/Sahara/Feature/Tab/SidebarView.swift
@@ -9,7 +9,7 @@ import SnapKit
 import UIKit
 
 final class SidebarView: UIView {
-    static let width: CGFloat = 72
+    static let width: CGFloat = 80
 
     private let stackView: UIStackView = {
         let stack = UIStackView()
@@ -20,12 +20,17 @@ final class SidebarView: UIView {
     }()
 
     private var tabButtons: [TabItem: TabButton] = [:]
+    private var stackTopConstraint: Constraint?
 
     var onTabSelected: ((TabItem) -> Void)?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupUI()
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(floatingWindowStateChanged),
+            name: .floatingWindowStateDidChange, object: nil
+        )
     }
 
     required init?(coder: NSCoder) {
@@ -51,9 +56,24 @@ final class SidebarView: UIView {
         }
 
         stackView.snp.makeConstraints { make in
-            make.top.equalTo(safeAreaLayoutGuide).offset(16)
+            stackTopConstraint = make.top.equalTo(safeAreaLayoutGuide).offset(16).constraint
             make.centerX.equalToSuperview()
         }
+    }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        updateTopForWindowControls(isFloating: isInFloatingWindow)
+    }
+
+    @objc private func floatingWindowStateChanged() {
+        updateTopForWindowControls(isFloating: isInFloatingWindow)
+    }
+
+    private func updateTopForWindowControls(isFloating: Bool) {
+        // 48: 윈도우 컨트롤(신호등) 아래 충분한 여백 확보
+        let top: CGFloat = isFloating ? 48 : 16
+        stackTopConstraint?.update(offset: top)
     }
 
     func setSelectedTab(_ tab: TabItem) {

--- a/Sahara/SceneDelegate.swift
+++ b/Sahara/SceneDelegate.swift
@@ -31,8 +31,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             return
         }
 
-        let mainTabBarController = MainTabBarController()
-        window?.rootViewController = mainTabBarController
+        window?.rootViewController = MainTabBarController()
 
         window?.makeKeyAndVisible()
 


### PR DESCRIPTION
Closes #70

## 변경 내용

**추가**
- 플로팅 윈도우 감지 유틸리티 (윈도우 크기와 스크린 크기 비교)
- 네비게이션 바에 콘텐츠 leading 가이드 추가 — 플로팅 모드에서 윈도우 컨트롤과 겹치지 않도록 좌측 여백 자동 조정
- 사이드바 플로팅 모드 상단 여백 추가 — 윈도우 컨트롤과 겹치지 않도록 조정

**수정**
- 사이드바 너비를 늘려 윈도우 컨트롤이 사이드바 중심에 정렬되도록 개선
- 플로팅 상태 감지를 각 뷰의 layoutSubviews 폴링에서 중앙 컨트롤러의 이벤트 기반 전파로 전환

## 결정 근거

- **Notification 기반 전파** — 플로팅 윈도우는 윈도우 레벨 상태이므로, 각 뷰가 layoutSubviews에서 독립적으로 폴링하는 대신 컨트롤러가 감지하고 Notification으로 전파하여 불필요한 반복 연산 제거