### PR TITLE
Improve thumbnail quality with continuous pixel sizing and aspect ratio correction

### DIFF
--- a/Sahara/Common/Service/ThumbnailCache.swift
+++ b/Sahara/Common/Service/ThumbnailCache.swift
@@ -11,26 +11,15 @@ import RealmSwift
 final class ThumbnailCache {
     static let shared = ThumbnailCache()
 
-    enum ThumbnailSize: String {
-        case small
-        case medium
-
-        var maxPixelSize: CGFloat {
-            switch self {
-            case .small: return 200
-            case .medium: return 600
-            }
-        }
-    }
-
     private let cacheDirectory: URL
     private let smallCache = NSCache<NSString, UIImage>()
-    private let mediumCache = NSCache<NSString, UIImage>()
+    private let largeCache = NSCache<NSString, UIImage>()
     private let serialQueue = DispatchQueue(label: "com.sahara.thumbnailCache.serial")
     private let loadQueue = DispatchQueue(label: "com.sahara.thumbnailCache.load", qos: .userInitiated, attributes: .concurrent)
 
     private var inFlightRequests: [String: [(UIImage?) -> Void]] = [:]
     private var aspectRatioCache: [ObjectId: CGFloat] = [:]
+    private var cachedKeys: [ObjectId: Set<String>] = [:]
 
     private init() {
         let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
@@ -40,15 +29,26 @@ final class ThumbnailCache {
         smallCache.countLimit = 300
         smallCache.totalCostLimit = 50 * 1024 * 1024
 
-        mediumCache.countLimit = 100
-        mediumCache.totalCostLimit = 100 * 1024 * 1024
+        largeCache.countLimit = 100
+        largeCache.totalCostLimit = 100 * 1024 * 1024
+    }
+
+    // MARK: - Public Helpers
+
+    static func bucket(_ pixelSize: CGFloat) -> Int {
+        max(Int(ceil(pixelSize / 100)) * 100, 100)
+    }
+
+    static func maxPixelSize(for pointSize: CGSize, scale: CGFloat) -> CGFloat {
+        max(pointSize.width, pointSize.height) * max(scale, 1)
     }
 
     // MARK: - Sync (memory → disk → Realm)
 
-    func thumbnail(for cardId: ObjectId, size: ThumbnailSize) -> UIImage? {
-        let key = cacheKey(cardId: cardId, size: size)
-        let cache = memoryCache(for: size)
+    func thumbnail(for cardId: ObjectId, maxPixelSize: CGFloat) -> UIImage? {
+        let bucketValue = Self.bucket(maxPixelSize)
+        let key = cacheKey(cardId: cardId, bucket: bucketValue)
+        let cache = memoryCache(forBucket: bucketValue)
 
         if let cached = cache.object(forKey: key as NSString) {
             return cached
@@ -56,24 +56,39 @@ final class ThumbnailCache {
 
         if let (image, data) = loadFromDisk(key: key) {
             cache.setObject(image, forKey: key as NSString, cost: data.count)
+            trackKey(key, for: cardId)
             return image
         }
 
-        guard let originalData = RealmService.shared.fetchImageData(for: cardId),
-              let thumbnail = ImageDownsampler.downsample(data: originalData, maxDimension: size.maxPixelSize) else {
+        guard let originalData = RealmService.shared.fetchImageData(for: cardId) else {
+            return nil
+        }
+
+        var effectiveDimension = CGFloat(bucketValue)
+        if let imageSize = ImageDownsampler.imageSize(from: originalData),
+           imageSize.width > 0, imageSize.height > 0 {
+            let longSide = max(imageSize.width, imageSize.height)
+            let shortSide = min(imageSize.width, imageSize.height)
+            let aspectMultiplier = min(longSide / shortSide, 2.0)
+            effectiveDimension = CGFloat(bucketValue) * aspectMultiplier
+        }
+
+        guard let thumbnail = ImageDownsampler.downsample(data: originalData, maxDimension: effectiveDimension) else {
             return nil
         }
 
         saveToDisk(thumbnail, key: key)
         cache.setObject(thumbnail, forKey: key as NSString)
+        trackKey(key, for: cardId)
         return thumbnail
     }
 
     // MARK: - Async (background, deduplicated)
 
-    func loadThumbnail(for cardId: ObjectId, size: ThumbnailSize, completion: @escaping (UIImage?) -> Void) {
-        let key = cacheKey(cardId: cardId, size: size)
-        let cache = memoryCache(for: size)
+    func loadThumbnail(for cardId: ObjectId, maxPixelSize: CGFloat, completion: @escaping (UIImage?) -> Void) {
+        let bucketValue = Self.bucket(maxPixelSize)
+        let key = cacheKey(cardId: cardId, bucket: bucketValue)
+        let cache = memoryCache(forBucket: bucketValue)
 
         if let cached = cache.object(forKey: key as NSString) {
             completion(cached)
@@ -98,12 +113,24 @@ final class ThumbnailCache {
 
             if let (image, data) = self.loadFromDisk(key: key) {
                 cache.setObject(image, forKey: key as NSString, cost: data.count)
+                self.trackKey(key, for: cardId)
                 result = image
-            } else if let originalData = RealmService.shared.fetchImageData(for: cardId),
-                      let thumbnail = ImageDownsampler.downsample(data: originalData, maxDimension: size.maxPixelSize) {
-                self.saveToDisk(thumbnail, key: key)
-                cache.setObject(thumbnail, forKey: key as NSString)
-                result = thumbnail
+            } else if let originalData = RealmService.shared.fetchImageData(for: cardId) {
+                var effectiveDimension = CGFloat(bucketValue)
+                if let imageSize = ImageDownsampler.imageSize(from: originalData),
+                   imageSize.width > 0, imageSize.height > 0 {
+                    let longSide = max(imageSize.width, imageSize.height)
+                    let shortSide = min(imageSize.width, imageSize.height)
+                    let aspectMultiplier = min(longSide / shortSide, 2.0)
+                    effectiveDimension = CGFloat(bucketValue) * aspectMultiplier
+                }
+
+                if let thumbnail = ImageDownsampler.downsample(data: originalData, maxDimension: effectiveDimension) {
+                    self.saveToDisk(thumbnail, key: key)
+                    cache.setObject(thumbnail, forKey: key as NSString)
+                    self.trackKey(key, for: cardId)
+                    result = thumbnail
+                }
             }
 
             let completions: [(UIImage?) -> Void] = self.serialQueue.sync {
@@ -123,14 +150,27 @@ final class ThumbnailCache {
             return cached
         }
 
-        for size in [ThumbnailSize.medium, .small] {
-            let key = cacheKey(cardId: cardId, size: size)
+        let keys: Set<String> = serialQueue.sync { cachedKeys[cardId] ?? [] }
+        for key in keys.sorted().reversed() {
             if let diskData = loadRawDataFromDisk(key: key),
                let imageSize = ImageDownsampler.imageSize(from: diskData),
                imageSize.width > 0 {
                 let ratio = imageSize.height / imageSize.width
                 serialQueue.sync { aspectRatioCache[cardId] = ratio }
                 return ratio
+            }
+        }
+
+        let prefix = cardId.stringValue
+        if let files = try? FileManager.default.contentsOfDirectory(at: cacheDirectory, includingPropertiesForKeys: nil) {
+            for file in files where file.deletingPathExtension().lastPathComponent.hasPrefix(prefix) {
+                if let diskData = try? Data(contentsOf: file),
+                   let imageSize = ImageDownsampler.imageSize(from: diskData),
+                   imageSize.width > 0 {
+                    let ratio = imageSize.height / imageSize.width
+                    serialQueue.sync { aspectRatioCache[cardId] = ratio }
+                    return ratio
+                }
             }
         }
 
@@ -149,19 +189,24 @@ final class ThumbnailCache {
 
     func clearAll() {
         smallCache.removeAllObjects()
-        mediumCache.removeAllObjects()
+        largeCache.removeAllObjects()
         serialQueue.sync {
             inFlightRequests.removeAll()
             aspectRatioCache.removeAll()
+            cachedKeys.removeAll()
         }
         try? FileManager.default.removeItem(at: cacheDirectory)
         try? FileManager.default.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
     }
 
     func invalidate(for cardId: ObjectId) {
-        for size in [ThumbnailSize.small, .medium] {
-            let key = cacheKey(cardId: cardId, size: size)
-            memoryCache(for: size).removeObject(forKey: key as NSString)
+        let keys: Set<String> = serialQueue.sync {
+            cachedKeys.removeValue(forKey: cardId) ?? []
+        }
+
+        for key in keys {
+            smallCache.removeObject(forKey: key as NSString)
+            largeCache.removeObject(forKey: key as NSString)
         }
 
         serialQueue.sync { aspectRatioCache[cardId] = nil }
@@ -176,15 +221,18 @@ final class ThumbnailCache {
 
     // MARK: - Private
 
-    private func memoryCache(for size: ThumbnailSize) -> NSCache<NSString, UIImage> {
-        switch size {
-        case .small: return smallCache
-        case .medium: return mediumCache
-        }
+    private func memoryCache(forBucket bucket: Int) -> NSCache<NSString, UIImage> {
+        bucket <= 400 ? smallCache : largeCache
     }
 
-    private func cacheKey(cardId: ObjectId, size: ThumbnailSize) -> String {
-        "\(cardId.stringValue)_\(size.rawValue)"
+    private func cacheKey(cardId: ObjectId, bucket: Int) -> String {
+        "\(cardId.stringValue)_\(bucket)"
+    }
+
+    private func trackKey(_ key: String, for cardId: ObjectId) {
+        serialQueue.async(flags: .barrier) {
+            self.cachedKeys[cardId, default: []].insert(key)
+        }
     }
 
     private func diskURL(for key: String, ext: String) -> URL {
@@ -220,7 +268,7 @@ final class ThumbnailCache {
                 try? data.write(to: diskURL(for: key, ext: "png"))
             }
         } else {
-            if let data = image.jpegData(compressionQuality: 0.7) {
+            if let data = image.jpegData(compressionQuality: 0.85) {
                 try? data.write(to: diskURL(for: key, ext: "jpg"))
             }
         }

--- a/Sahara/Feature/Gallery/CardList/CardThumbnailCell.swift
+++ b/Sahara/Feature/Gallery/CardList/CardThumbnailCell.swift
@@ -9,15 +9,19 @@ import UIKit
 
 final class CardThumbnailCell: BaseCardThumbnailCell {
 
+    private var thumbnailPixelSize: CGFloat {
+        ThumbnailCache.maxPixelSize(for: bounds.size, scale: traitCollection.displayScale)
+    }
+
     func configure(with item: CardListItemDTO) {
-        ThumbnailCache.shared.loadThumbnail(for: item.id, size: .medium) { [weak self] image in
+        ThumbnailCache.shared.loadThumbnail(for: item.id, maxPixelSize: thumbnailPixelSize) { [weak self] image in
             self?.imageView.image = image
         }
         setBlur(isHidden: !item.isLocked)
     }
 
     func configure(with item: SearchCardDTO) {
-        ThumbnailCache.shared.loadThumbnail(for: item.id, size: .medium) { [weak self] image in
+        ThumbnailCache.shared.loadThumbnail(for: item.id, maxPixelSize: thumbnailPixelSize) { [weak self] image in
             self?.imageView.image = image
         }
         setBlur(isHidden: !item.isLocked)

--- a/Sahara/Feature/Gallery/GalleryViewController.swift
+++ b/Sahara/Feature/Gallery/GalleryViewController.swift
@@ -403,7 +403,8 @@ extension GalleryViewController: MKMapViewDelegate {
             let sortedPhotos = allPhotos.sorted { !$0.isLocked && $1.isLocked }
 
             if let firstPhoto = sortedPhotos.first {
-                representativeImage = ThumbnailCache.shared.thumbnail(for: firstPhoto.id, size: .small)
+                let annotationPixelSize = 50 * max(view.traitCollection.displayScale, 1)
+                representativeImage = ThumbnailCache.shared.thumbnail(for: firstPhoto.id, maxPixelSize: annotationPixelSize)
                 isLocked = firstPhoto.isLocked
             }
 
@@ -426,9 +427,11 @@ extension GalleryViewController: MKMapViewDelegate {
         let photos = photoAnnotation.cardIds.compactMap { realmManager.fetchObject(Card.self, forPrimaryKey: $0) }
         let sortedPhotos = photos.sorted { !$0.isLocked && $1.isLocked }
 
-        if let firstPhoto = sortedPhotos.first,
-           let image = ThumbnailCache.shared.thumbnail(for: firstPhoto.id, size: .small) {
-            annotationView?.configure(with: image, isLocked: firstPhoto.isLocked)
+        if let firstPhoto = sortedPhotos.first {
+            let annotationPixelSize = 50 * max(view.traitCollection.displayScale, 1)
+            if let image = ThumbnailCache.shared.thumbnail(for: firstPhoto.id, maxPixelSize: annotationPixelSize) {
+                annotationView?.configure(with: image, isLocked: firstPhoto.isLocked)
+            }
         }
 
         return annotationView

--- a/Sahara/Feature/Gallery/Tab/Calendar/CalendarCell.swift
+++ b/Sahara/Feature/Gallery/Tab/Calendar/CalendarCell.swift
@@ -32,6 +32,10 @@ final class CalendarCell: UICollectionViewCell, IsIdentifiable {
     private var blurViews: [UIVisualEffectView] = []
     private var isToday = false
 
+    private var thumbnailPixelSize: CGFloat {
+        ThumbnailCache.maxPixelSize(for: bounds.size, scale: traitCollection.displayScale)
+    }
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         configureUI()
@@ -128,7 +132,7 @@ final class CalendarCell: UICollectionViewCell, IsIdentifiable {
         imageViews.append(imageView)
         containerView.addSubview(imageView)
 
-        ThumbnailCache.shared.loadThumbnail(for: card.id, size: .small) { [weak imageView] image in
+        ThumbnailCache.shared.loadThumbnail(for: card.id, maxPixelSize: thumbnailPixelSize) { [weak imageView] image in
             imageView?.image = image
         }
         imageView.layer.cornerRadius = 8
@@ -157,10 +161,10 @@ final class CalendarCell: UICollectionViewCell, IsIdentifiable {
         containerView.addSubview(imageView1)
         containerView.addSubview(imageView2)
 
-        ThumbnailCache.shared.loadThumbnail(for: photo1.id, size: .small) { [weak imageView1] image in
+        ThumbnailCache.shared.loadThumbnail(for: photo1.id, maxPixelSize: thumbnailPixelSize) { [weak imageView1] image in
             imageView1?.image = image
         }
-        ThumbnailCache.shared.loadThumbnail(for: photo2.id, size: .small) { [weak imageView2] image in
+        ThumbnailCache.shared.loadThumbnail(for: photo2.id, maxPixelSize: thumbnailPixelSize) { [weak imageView2] image in
             imageView2?.image = image
         }
 
@@ -215,13 +219,13 @@ final class CalendarCell: UICollectionViewCell, IsIdentifiable {
         containerView.addSubview(bottomLeftImageView)
         containerView.addSubview(bottomRightImageView)
 
-        ThumbnailCache.shared.loadThumbnail(for: cards[0].id, size: .small) { [weak topImageView] image in
+        ThumbnailCache.shared.loadThumbnail(for: cards[0].id, maxPixelSize: thumbnailPixelSize) { [weak topImageView] image in
             topImageView?.image = image
         }
-        ThumbnailCache.shared.loadThumbnail(for: cards[1].id, size: .small) { [weak bottomLeftImageView] image in
+        ThumbnailCache.shared.loadThumbnail(for: cards[1].id, maxPixelSize: thumbnailPixelSize) { [weak bottomLeftImageView] image in
             bottomLeftImageView?.image = image
         }
-        ThumbnailCache.shared.loadThumbnail(for: cards[2].id, size: .small) { [weak bottomRightImageView] image in
+        ThumbnailCache.shared.loadThumbnail(for: cards[2].id, maxPixelSize: thumbnailPixelSize) { [weak bottomRightImageView] image in
             bottomRightImageView?.image = image
         }
 

--- a/Sahara/Feature/Gallery/Tab/Folder/FolderCell.swift
+++ b/Sahara/Feature/Gallery/Tab/Folder/FolderCell.swift
@@ -47,6 +47,10 @@ final class FolderCell: UICollectionViewCell, IsIdentifiable {
 
     private var imageViews: [UIImageView] = []
 
+    private var thumbnailPixelSize: CGFloat {
+        ThumbnailCache.maxPixelSize(for: thumbnailContainerView.bounds.size, scale: traitCollection.displayScale)
+    }
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         configureUI()
@@ -108,7 +112,7 @@ final class FolderCell: UICollectionViewCell, IsIdentifiable {
         imageViews.append(imageView)
         thumbnailContainerView.addSubview(imageView)
 
-        ThumbnailCache.shared.loadThumbnail(for: card.id, size: .small) { [weak imageView] image in
+        ThumbnailCache.shared.loadThumbnail(for: card.id, maxPixelSize: thumbnailPixelSize) { [weak imageView] image in
             imageView?.image = image
         }
 
@@ -125,10 +129,10 @@ final class FolderCell: UICollectionViewCell, IsIdentifiable {
         thumbnailContainerView.addSubview(imageView1)
         thumbnailContainerView.addSubview(imageView2)
 
-        ThumbnailCache.shared.loadThumbnail(for: card1.id, size: .small) { [weak imageView1] image in
+        ThumbnailCache.shared.loadThumbnail(for: card1.id, maxPixelSize: thumbnailPixelSize) { [weak imageView1] image in
             imageView1?.image = image
         }
-        ThumbnailCache.shared.loadThumbnail(for: card2.id, size: .small) { [weak imageView2] image in
+        ThumbnailCache.shared.loadThumbnail(for: card2.id, maxPixelSize: thumbnailPixelSize) { [weak imageView2] image in
             imageView2?.image = image
         }
 
@@ -155,13 +159,13 @@ final class FolderCell: UICollectionViewCell, IsIdentifiable {
         thumbnailContainerView.addSubview(bottomLeftImageView)
         thumbnailContainerView.addSubview(bottomRightImageView)
 
-        ThumbnailCache.shared.loadThumbnail(for: cards[0].id, size: .small) { [weak topImageView] image in
+        ThumbnailCache.shared.loadThumbnail(for: cards[0].id, maxPixelSize: thumbnailPixelSize) { [weak topImageView] image in
             topImageView?.image = image
         }
-        ThumbnailCache.shared.loadThumbnail(for: cards[1].id, size: .small) { [weak bottomLeftImageView] image in
+        ThumbnailCache.shared.loadThumbnail(for: cards[1].id, maxPixelSize: thumbnailPixelSize) { [weak bottomLeftImageView] image in
             bottomLeftImageView?.image = image
         }
-        ThumbnailCache.shared.loadThumbnail(for: cards[2].id, size: .small) { [weak bottomRightImageView] image in
+        ThumbnailCache.shared.loadThumbnail(for: cards[2].id, maxPixelSize: thumbnailPixelSize) { [weak bottomRightImageView] image in
             bottomRightImageView?.image = image
         }
 

--- a/Sahara/Feature/Gallery/Tab/Theme/ThemeCell.swift
+++ b/Sahara/Feature/Gallery/Tab/Theme/ThemeCell.swift
@@ -82,7 +82,8 @@ final class ThemeCell: UITableViewCell, IsIdentifiable {
 
         if let firstPhoto = sortedPhotos.first {
             blurEffectView.isHidden = !firstPhoto.isLocked
-            ThumbnailCache.shared.loadThumbnail(for: firstPhoto.id, size: .small) { [weak self] image in
+            let pixelSize = 80 * max(traitCollection.displayScale, 1)
+            ThumbnailCache.shared.loadThumbnail(for: firstPhoto.id, maxPixelSize: pixelSize) { [weak self] image in
                 self?.thumbnailImageView.image = image
             }
         }

--- a/Sahara/Feature/Tab/MainTabBarController.swift
+++ b/Sahara/Feature/Tab/MainTabBarController.swift
@@ -91,6 +91,9 @@ final class MainTabBarController: UIViewController, SidebarToggleable {
         super.viewDidLoad()
         setupNavigationUI()
         setupViewControllers()
+        registerForTraitChanges([UITraitHorizontalSizeClass.self]) { (self: Self, previousTraitCollection: UITraitCollection) in
+            self.transitionNavigationUI()
+        }
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -103,12 +106,6 @@ final class MainTabBarController: UIViewController, SidebarToggleable {
         coordinator.animate(alongsideTransition: nil) { _ in
             self.checkFloatingWindowState()
         }
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        guard previousTraitCollection?.horizontalSizeClass != traitCollection.horizontalSizeClass else { return }
-        transitionNavigationUI()
     }
 
     private func checkFloatingWindowState() {


### PR DESCRIPTION
Closes #46

## 변경 내용

**추가**
- 셀 크기와 화면 스케일에 기반한 연속적 픽셀 크기 계산 (고정 enum 대신 100px 단위 버킷 시스템)
- 원본 이미지의 종횡비를 반영한 다운샘플링 보정 — 세로로 긴 이미지의 잘림 현상 해소
- 썸네일 키 추적으로 카드별 캐시 무효화 정확도 향상
- 디스크 캐시 디렉토리 스캔 폴백으로 메모리 캐시 미적중 시에도 종횡비 조회 가능

**수정**
- 캐시 디렉토리명 변경으로 기존 저품질 캐시 자동 무효화
- JPEG 압축 품질 0.7 → 0.85로 상향
- deprecated `traitCollectionDidChange` → `registerForTraitChanges` 전환

## 결정 근거

- **100px 버킷** — 해상도별로 개별 캐시를 만들면 디스크 사용량이 급증하므로, 100px 단위로 그룹핑하여 캐시 효율과 품질 사이 균형을 맞춤
- **aspectMultiplier cap 2.0** — 극단적 파노라마 이미지에서 불필요하게 큰 썸네일이 생성되는 것을 방지
- **캐시 디렉토리명 변경** — 기존 `thumbnails_v2`의 저품질 캐시가 계속 서빙되는 문제를 디렉토리 변경으로 자연스럽게 해결