### PR TITLE
Re-evaluate calendar cell image layout on bounds change

### DIFF
--- a/Sahara/Feature/Gallery/Tab/Calendar/CalendarCell.swift
+++ b/Sahara/Feature/Gallery/Tab/Calendar/CalendarCell.swift
@@ -10,6 +10,41 @@ import SnapKit
 import UIKit
 
 final class CalendarCell: UICollectionViewCell, IsIdentifiable {
+
+    // MARK: - Layout Decision
+
+    private enum CellImageLayout {
+        case single
+        case twoVertical      // 상/하 분할 (세로형 셀)
+        case twoHorizontal    // 좌/우 분할 (가로형 셀)
+        case threeTopOne      // 위1 + 아래2 (세로형 셀)
+        case threeLeftOne     // 왼쪽1 + 오른쪽2 (가로형 셀)
+        case fourGrid         // 2×2 그리드
+    }
+
+    private func decideLayout(photoCount: Int) -> CellImageLayout {
+        let cellSize = bounds.size
+        guard cellSize.width > 0, cellSize.height > 0 else { return .single }
+
+        let minDim = min(cellSize.width, cellSize.height)
+        let isLandscape = cellSize.width > cellSize.height
+
+        if photoCount <= 1 || minDim < 40 { return .single }
+
+        if photoCount == 2 {
+            return isLandscape ? .twoHorizontal : .twoVertical
+        }
+
+        if photoCount == 3 {
+            return isLandscape ? .threeLeftOne : .threeTopOne
+        }
+
+        if minDim < 80 {
+            return isLandscape ? .threeLeftOne : .threeTopOne
+        }
+
+        return .fourGrid
+    }
     private let containerView = UIView()
 
     private var dayLabel: UILabel = {
@@ -31,6 +66,9 @@ final class CalendarCell: UICollectionViewCell, IsIdentifiable {
     private var imageViews: [UIImageView] = []
     private var blurViews: [UIVisualEffectView] = []
     private var isToday = false
+    private var cachedSortedCards: [CardCalendarItemDTO] = []
+    private var cachedLayoutDecision: CellImageLayout?
+    private var cachedBoundsSize: CGSize = .zero
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -38,6 +76,21 @@ final class CalendarCell: UICollectionViewCell, IsIdentifiable {
     }
 
     required init?(coder: NSCoder) { fatalError() }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        guard bounds.size != cachedBoundsSize else { return }
+        guard !cachedSortedCards.isEmpty else {
+            cachedBoundsSize = bounds.size
+            return
+        }
+        let newDecision = decideLayout(photoCount: cachedSortedCards.count)
+        guard newDecision != cachedLayoutDecision else {
+            cachedBoundsSize = bounds.size
+            return
+        }
+        applyImageLayout(sortedCards: cachedSortedCards)
+    }
 
     private func configureUI() {
         contentView.backgroundColor = .clear
@@ -63,10 +116,11 @@ final class CalendarCell: UICollectionViewCell, IsIdentifiable {
     }
 
     func configure(with item: DayItem) {
-        imageViews.forEach { $0.removeFromSuperview() }
-        imageViews.removeAll()
-        blurViews.forEach { $0.removeFromSuperview() }
-        blurViews.removeAll()
+        cachedSortedCards = []
+        cachedLayoutDecision = nil
+        cachedBoundsSize = .zero
+
+        clearImageAndBlurViews()
 
         isToday = false
         addButton.isHidden = true
@@ -93,25 +147,19 @@ final class CalendarCell: UICollectionViewCell, IsIdentifiable {
             }
 
             let sortedCards = item.cards.sorted { !$0.isLocked && $1.isLocked }
-            let photoCount = sortedCards.count
+            cachedSortedCards = sortedCards
 
-            let shouldShowBorder = isTodayDate && photoCount == 0
+            let shouldShowBorder = isTodayDate && sortedCards.isEmpty
 
             contentView.layer.borderColor = shouldShowBorder ? UIColor.token(.border).cgColor : nil
             contentView.layer.borderWidth = shouldShowBorder ? 2 : 0
 
-            if photoCount == 0 {
+            if sortedCards.isEmpty {
                 containerView.backgroundColor = .clear
                 addButton.isHidden = !isTodayDate
             } else {
                 addButton.isHidden = true
-                if photoCount == 1 {
-                    layoutSingleImage(sortedCards[0])
-                } else if photoCount == 2 {
-                    layoutTwoImages(sortedCards[0], sortedCards[1])
-                } else {
-                    layoutMultipleImages(cards: Array(sortedCards.prefix(3)))
-                }
+                applyImageLayout(sortedCards: sortedCards)
             }
         } else {
             dayLabel.text = ""
@@ -120,6 +168,30 @@ final class CalendarCell: UICollectionViewCell, IsIdentifiable {
             addButton.isHidden = true
             contentView.layer.borderColor = nil
             contentView.layer.borderWidth = 0
+        }
+    }
+
+    private func applyImageLayout(sortedCards: [CardCalendarItemDTO]) {
+        clearImageAndBlurViews()
+
+        let photoCount = sortedCards.count
+        let layout = decideLayout(photoCount: photoCount)
+        cachedLayoutDecision = layout
+        cachedBoundsSize = bounds.size
+
+        switch layout {
+        case .single:
+            layoutSingleImage(sortedCards[0])
+        case .twoVertical:
+            layoutTwoImages(sortedCards[0], sortedCards[min(1, photoCount - 1)])
+        case .twoHorizontal:
+            layoutTwoHorizontalImages(sortedCards[0], sortedCards[min(1, photoCount - 1)])
+        case .threeTopOne:
+            layoutMultipleImages(cards: Array(sortedCards.prefix(3)))
+        case .threeLeftOne:
+            layoutThreeLeftOneImages(cards: Array(sortedCards.prefix(3)))
+        case .fourGrid:
+            layoutFourGridImages(cards: Array(sortedCards.prefix(4)))
         }
     }
 
@@ -138,15 +210,7 @@ final class CalendarCell: UICollectionViewCell, IsIdentifiable {
             make.edges.equalToSuperview()
         }
 
-        if card.isLocked {
-            let blurView = createBlurView()
-            blurView.layer.cornerRadius = 8
-            blurViews.append(blurView)
-            containerView.addSubview(blurView)
-            blurView.snp.makeConstraints { make in
-                make.edges.equalTo(imageView)
-            }
-        }
+        addBlurIfLocked(card, over: imageView)
     }
 
     private func layoutTwoImages(_ photo1: CardCalendarItemDTO, _ photo2: CardCalendarItemDTO) {
@@ -180,27 +244,50 @@ final class CalendarCell: UICollectionViewCell, IsIdentifiable {
             make.top.equalTo(containerView.snp.centerY).offset(0.5)
         }
 
-        if photo1.isLocked {
-            let blurView = createBlurView()
-            blurView.layer.cornerRadius = 8
-            blurView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
-            blurViews.append(blurView)
-            containerView.addSubview(blurView)
-            blurView.snp.makeConstraints { make in
-                make.edges.equalTo(imageView1)
-            }
+        addBlurIfLocked(photo1, over: imageView1, corners: [.layerMinXMinYCorner, .layerMaxXMinYCorner])
+        addBlurIfLocked(photo2, over: imageView2, corners: [.layerMinXMaxYCorner, .layerMaxXMaxYCorner])
+    }
+
+    // MARK: - 좌/우 분할 (가로형 셀, 2장)
+    //  ┌──────┬──────┐
+    //  │      │      │
+    //  │ img1 │ img2 │
+    //  │      │      │
+    //  └──────┴──────┘
+
+    private func layoutTwoHorizontalImages(_ photo1: CardCalendarItemDTO, _ photo2: CardCalendarItemDTO) {
+        let imageView1 = createImageView()
+        let imageView2 = createImageView()
+
+        imageViews.append(contentsOf: [imageView1, imageView2])
+        containerView.addSubview(imageView1)
+        containerView.addSubview(imageView2)
+
+        ThumbnailCache.shared.loadThumbnail(for: photo1.id, size: .small) { [weak imageView1] image in
+            imageView1?.image = image
+        }
+        ThumbnailCache.shared.loadThumbnail(for: photo2.id, size: .small) { [weak imageView2] image in
+            imageView2?.image = image
         }
 
-        if photo2.isLocked {
-            let blurView = createBlurView()
-            blurView.layer.cornerRadius = 8
-            blurView.layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
-            blurViews.append(blurView)
-            containerView.addSubview(blurView)
-            blurView.snp.makeConstraints { make in
-                make.edges.equalTo(imageView2)
-            }
+        imageView1.layer.cornerRadius = 8
+        imageView1.layer.maskedCorners = [.layerMinXMinYCorner, .layerMinXMaxYCorner]
+
+        imageView2.layer.cornerRadius = 8
+        imageView2.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMaxXMaxYCorner]
+
+        imageView1.snp.makeConstraints { make in
+            make.top.leading.bottom.equalToSuperview()
+            make.trailing.equalTo(containerView.snp.centerX).offset(-0.5)
         }
+
+        imageView2.snp.makeConstraints { make in
+            make.top.trailing.bottom.equalToSuperview()
+            make.leading.equalTo(containerView.snp.centerX).offset(0.5)
+        }
+
+        addBlurIfLocked(photo1, over: imageView1, corners: [.layerMinXMinYCorner, .layerMinXMaxYCorner])
+        addBlurIfLocked(photo2, over: imageView2, corners: [.layerMaxXMinYCorner, .layerMaxXMaxYCorner])
     }
 
     private func layoutMultipleImages(cards: [CardCalendarItemDTO]) {
@@ -251,37 +338,165 @@ final class CalendarCell: UICollectionViewCell, IsIdentifiable {
             make.leading.equalTo(containerView.snp.centerX).offset(0.5)
         }
 
-        if cards[0].isLocked {
-            let blurView = createBlurView()
-            blurView.layer.cornerRadius = 8
-            blurView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
-            blurViews.append(blurView)
-            containerView.addSubview(blurView)
-            blurView.snp.makeConstraints { make in
-                make.edges.equalTo(topImageView)
+        addBlurIfLocked(cards[0], over: topImageView, corners: [.layerMinXMinYCorner, .layerMaxXMinYCorner])
+        addBlurIfLocked(cards[1], over: bottomLeftImageView, corners: [.layerMinXMaxYCorner])
+        addBlurIfLocked(cards[2], over: bottomRightImageView, corners: [.layerMaxXMaxYCorner])
+    }
+
+    // MARK: - 왼쪽1 + 오른쪽2 (가로형 셀, 3장)
+    //  ┌──────┬──────┐
+    //  │      │ img2 │
+    //  │ img1 ├──────┤
+    //  │      │ img3 │
+    //  └──────┴──────┘
+
+    private func layoutThreeLeftOneImages(cards: [CardCalendarItemDTO]) {
+        guard cards.count >= 3 else { return }
+
+        let leftImageView = createImageView()
+        let topRightImageView = createImageView()
+        let bottomRightImageView = createImageView()
+
+        imageViews.append(contentsOf: [leftImageView, topRightImageView, bottomRightImageView])
+        containerView.addSubview(leftImageView)
+        containerView.addSubview(topRightImageView)
+        containerView.addSubview(bottomRightImageView)
+
+        ThumbnailCache.shared.loadThumbnail(for: cards[0].id, size: .small) { [weak leftImageView] image in
+            leftImageView?.image = image
+        }
+        ThumbnailCache.shared.loadThumbnail(for: cards[1].id, size: .small) { [weak topRightImageView] image in
+            topRightImageView?.image = image
+        }
+        ThumbnailCache.shared.loadThumbnail(for: cards[2].id, size: .small) { [weak bottomRightImageView] image in
+            bottomRightImageView?.image = image
+        }
+
+        leftImageView.layer.cornerRadius = 8
+        leftImageView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMinXMaxYCorner]
+
+        topRightImageView.layer.cornerRadius = 8
+        topRightImageView.layer.maskedCorners = [.layerMaxXMinYCorner]
+
+        bottomRightImageView.layer.cornerRadius = 8
+        bottomRightImageView.layer.maskedCorners = [.layerMaxXMaxYCorner]
+
+        leftImageView.snp.makeConstraints { make in
+            make.top.leading.bottom.equalToSuperview()
+            make.trailing.equalTo(containerView.snp.centerX).offset(-0.5)
+        }
+
+        topRightImageView.snp.makeConstraints { make in
+            make.top.trailing.equalToSuperview()
+            make.leading.equalTo(containerView.snp.centerX).offset(0.5)
+            make.bottom.equalTo(containerView.snp.centerY).offset(-0.5)
+        }
+
+        bottomRightImageView.snp.makeConstraints { make in
+            make.bottom.trailing.equalToSuperview()
+            make.leading.equalTo(containerView.snp.centerX).offset(0.5)
+            make.top.equalTo(containerView.snp.centerY).offset(0.5)
+        }
+
+        addBlurIfLocked(cards[0], over: leftImageView, corners: [.layerMinXMinYCorner, .layerMinXMaxYCorner])
+        addBlurIfLocked(cards[1], over: topRightImageView, corners: [.layerMaxXMinYCorner])
+        addBlurIfLocked(cards[2], over: bottomRightImageView, corners: [.layerMaxXMaxYCorner])
+    }
+
+    // MARK: - 2×2 그리드 (4장)
+    //  ┌──────┬──────┐
+    //  │ img1 │ img2 │
+    //  ├──────┼──────┤
+    //  │ img3 │ img4 │
+    //  └──────┴──────┘
+
+    private func layoutFourGridImages(cards: [CardCalendarItemDTO]) {
+        guard cards.count >= 4 else { return }
+
+        let topLeft = createImageView()
+        let topRight = createImageView()
+        let bottomLeft = createImageView()
+        let bottomRight = createImageView()
+
+        let views = [topLeft, topRight, bottomLeft, bottomRight]
+        imageViews.append(contentsOf: views)
+        views.forEach { containerView.addSubview($0) }
+
+        for (index, card) in cards.prefix(4).enumerated() {
+            let imageView = views[index]
+            ThumbnailCache.shared.loadThumbnail(for: card.id, size: .small) { [weak imageView] image in
+                imageView?.image = image
             }
         }
 
-        if cards[1].isLocked {
-            let blurView = createBlurView()
-            blurView.layer.cornerRadius = 8
-            blurView.layer.maskedCorners = [.layerMinXMaxYCorner]
-            blurViews.append(blurView)
-            containerView.addSubview(blurView)
-            blurView.snp.makeConstraints { make in
-                make.edges.equalTo(bottomLeftImageView)
-            }
+        topLeft.layer.cornerRadius = 8
+        topLeft.layer.maskedCorners = [.layerMinXMinYCorner]
+
+        topRight.layer.cornerRadius = 8
+        topRight.layer.maskedCorners = [.layerMaxXMinYCorner]
+
+        bottomLeft.layer.cornerRadius = 8
+        bottomLeft.layer.maskedCorners = [.layerMinXMaxYCorner]
+
+        bottomRight.layer.cornerRadius = 8
+        bottomRight.layer.maskedCorners = [.layerMaxXMaxYCorner]
+
+        topLeft.snp.makeConstraints { make in
+            make.top.leading.equalToSuperview()
+            make.trailing.equalTo(containerView.snp.centerX).offset(-0.5)
+            make.bottom.equalTo(containerView.snp.centerY).offset(-0.5)
         }
 
-        if cards[2].isLocked {
-            let blurView = createBlurView()
-            blurView.layer.cornerRadius = 8
-            blurView.layer.maskedCorners = [.layerMaxXMaxYCorner]
-            blurViews.append(blurView)
-            containerView.addSubview(blurView)
-            blurView.snp.makeConstraints { make in
-                make.edges.equalTo(bottomRightImageView)
-            }
+        topRight.snp.makeConstraints { make in
+            make.top.trailing.equalToSuperview()
+            make.leading.equalTo(containerView.snp.centerX).offset(0.5)
+            make.bottom.equalTo(containerView.snp.centerY).offset(-0.5)
+        }
+
+        bottomLeft.snp.makeConstraints { make in
+            make.bottom.leading.equalToSuperview()
+            make.trailing.equalTo(containerView.snp.centerX).offset(-0.5)
+            make.top.equalTo(containerView.snp.centerY).offset(0.5)
+        }
+
+        bottomRight.snp.makeConstraints { make in
+            make.bottom.trailing.equalToSuperview()
+            make.leading.equalTo(containerView.snp.centerX).offset(0.5)
+            make.top.equalTo(containerView.snp.centerY).offset(0.5)
+        }
+
+        let corners: [CACornerMask] = [
+            [.layerMinXMinYCorner],
+            [.layerMaxXMinYCorner],
+            [.layerMinXMaxYCorner],
+            [.layerMaxXMaxYCorner]
+        ]
+
+        for (index, card) in cards.prefix(4).enumerated() {
+            addBlurIfLocked(card, over: views[index], corners: corners[index])
+        }
+    }
+
+    private func clearImageAndBlurViews() {
+        imageViews.forEach { $0.removeFromSuperview() }
+        imageViews.removeAll()
+        blurViews.forEach { $0.removeFromSuperview() }
+        blurViews.removeAll()
+    }
+
+    private func addBlurIfLocked(
+        _ card: CardCalendarItemDTO,
+        over imageView: UIImageView,
+        corners: CACornerMask = [.layerMinXMinYCorner, .layerMaxXMinYCorner, .layerMinXMaxYCorner, .layerMaxXMaxYCorner]
+    ) {
+        guard card.isLocked else { return }
+        let blurView = createBlurView()
+        blurView.layer.cornerRadius = 8
+        blurView.layer.maskedCorners = corners
+        blurViews.append(blurView)
+        containerView.addSubview(blurView)
+        blurView.snp.makeConstraints { make in
+            make.edges.equalTo(imageView)
         }
     }
 
@@ -310,13 +525,13 @@ final class CalendarCell: UICollectionViewCell, IsIdentifiable {
 
     override func prepareForReuse() {
         super.prepareForReuse()
-        imageViews.forEach { $0.removeFromSuperview() }
-        imageViews.removeAll()
-        blurViews.forEach { $0.removeFromSuperview() }
-        blurViews.removeAll()
+        clearImageAndBlurViews()
         dayLabel.text = ""
         contentView.layer.borderWidth = 0
         isToday = false
         addButton.isHidden = true
+        cachedSortedCards = []
+        cachedLayoutDecision = nil
+        cachedBoundsSize = .zero
     }
 }

--- a/Sahara/Feature/Gallery/Tab/Calendar/CalendarCell.swift
+++ b/Sahara/Feature/Gallery/Tab/Calendar/CalendarCell.swift
@@ -267,10 +267,10 @@ final class CalendarCell: UICollectionViewCell, IsIdentifiable {
         containerView.addSubview(imageView1)
         containerView.addSubview(imageView2)
 
-        ThumbnailCache.shared.loadThumbnail(for: photo1.id, size: .small) { [weak imageView1] image in
+        ThumbnailCache.shared.loadThumbnail(for: photo1.id, maxPixelSize: thumbnailPixelSize) { [weak imageView1] image in
             imageView1?.image = image
         }
-        ThumbnailCache.shared.loadThumbnail(for: photo2.id, size: .small) { [weak imageView2] image in
+        ThumbnailCache.shared.loadThumbnail(for: photo2.id, maxPixelSize: thumbnailPixelSize) { [weak imageView2] image in
             imageView2?.image = image
         }
 
@@ -366,13 +366,13 @@ final class CalendarCell: UICollectionViewCell, IsIdentifiable {
         containerView.addSubview(topRightImageView)
         containerView.addSubview(bottomRightImageView)
 
-        ThumbnailCache.shared.loadThumbnail(for: cards[0].id, size: .small) { [weak leftImageView] image in
+        ThumbnailCache.shared.loadThumbnail(for: cards[0].id, maxPixelSize: thumbnailPixelSize) { [weak leftImageView] image in
             leftImageView?.image = image
         }
-        ThumbnailCache.shared.loadThumbnail(for: cards[1].id, size: .small) { [weak topRightImageView] image in
+        ThumbnailCache.shared.loadThumbnail(for: cards[1].id, maxPixelSize: thumbnailPixelSize) { [weak topRightImageView] image in
             topRightImageView?.image = image
         }
-        ThumbnailCache.shared.loadThumbnail(for: cards[2].id, size: .small) { [weak bottomRightImageView] image in
+        ThumbnailCache.shared.loadThumbnail(for: cards[2].id, maxPixelSize: thumbnailPixelSize) { [weak bottomRightImageView] image in
             bottomRightImageView?.image = image
         }
 
@@ -428,7 +428,7 @@ final class CalendarCell: UICollectionViewCell, IsIdentifiable {
 
         for (index, card) in cards.prefix(4).enumerated() {
             let imageView = views[index]
-            ThumbnailCache.shared.loadThumbnail(for: card.id, size: .small) { [weak imageView] image in
+            ThumbnailCache.shared.loadThumbnail(for: card.id, maxPixelSize: thumbnailPixelSize) { [weak imageView] image in
                 imageView?.image = image
             }
         }


### PR DESCRIPTION
Closes #73

## 변경 내용

**추가**
- 셀 크기 기반 적응형 이미지 분할 결정 (세로형/가로형 자동 전환)
- 가로형 셀 전용 레이아웃: 좌/우 2분할, 왼쪽1+오른쪽2 분할, 2×2 그리드
- 셀 bounds 변경 시 레이아웃 결정을 재평가하여 회전/리사이즈 대응

**수정**
- 이미지 뷰 정리 및 blur 오버레이 로직을 헬퍼 메서드로 추출하여 중복 제거

## 결정 근거

- **layoutSubviews 기반** — invalidateLayout/configure 재호출 없이 셀 자체에서 bounds 변화를 감지하므로, 기존 데이터 플로우를 변경하지 않습니다
- **3단 guard 체인** — bounds 비교(나노초) → 정렬 캐시 확인 → 레이아웃 결정 비교 순서로, 대부분의 호출을 첫 번째 guard에서 차단합니다
- **정렬 결과 캐싱** — configure 시점에 한 번 정렬한 결과를 저장하여 layoutSubviews에서 매번 재정렬하지 않습니다