### PR TITLE
Replace PKToolPicker with custom drawing tool strip

### DIFF
--- a/Sahara/Feature/Gallery/GalleryViewController.swift
+++ b/Sahara/Feature/Gallery/GalleryViewController.swift
@@ -350,7 +350,7 @@ final class GalleryViewController: UIViewController {
             if type == selectedType {
                 button.setGradient(.ctaBlue, isSelected: true)
             } else {
-                button.setGradient(.subtle, isSelected: false)
+                button.setGradient(.tabBar, isSelected: false)
             }
         }
     }

--- a/Sahara/Feature/Gallery/Tab/Calendar/CalendarHeaderView.swift
+++ b/Sahara/Feature/Gallery/Tab/Calendar/CalendarHeaderView.swift
@@ -131,8 +131,8 @@ final class CalendarHeaderView: UICollectionReusableView {
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        previousMonthButton.applyGradient(.subtle, removeExisting: true)
-        nextMonthButton.applyGradient(.subtle, removeExisting: true)
+        previousMonthButton.applyGradient(.tabBar, removeExisting: true)
+        nextMonthButton.applyGradient(.tabBar, removeExisting: true)
     }
 
     func configure(monthTitle: String) {

--- a/Sahara/Feature/MediaEditor/MediaEditorViewController+Mode.swift
+++ b/Sahara/Feature/MediaEditor/MediaEditorViewController+Mode.swift
@@ -11,8 +11,8 @@ import UIKit
 extension MediaEditorViewController {
     func updateEditMode(mode: EditMode?) {
         filterCollectionView.isHidden = true
+        drawingToolStrip.isHidden = true
         canvasView.isUserInteractionEnabled = false
-        toolPicker.setVisible(false, forFirstResponder: canvasView)
         photoImageView.isUserInteractionEnabled = false
         stickerContainerView.isUserInteractionEnabled = true
         cropOverlayView.isHidden = true
@@ -66,29 +66,13 @@ extension MediaEditorViewController {
             break
         case .drawing:
             canvasView.isUserInteractionEnabled = true
-            undoButton.isHidden = false
-            redoButton.isHidden = false
-
-            toolBarContainer.snp.remakeConstraints { make in
-                make.leading.trailing.equalToSuperview()
-                make.height.equalTo(88)
-                make.bottom.equalTo(view.safeAreaLayoutGuide).offset(-75)
+            canvasView.becomeFirstResponder()
+            drawingToolStrip.alpha = 0
+            drawingToolStrip.isHidden = false
+            UIView.animate(withDuration: 0.25) {
+                self.drawingToolStrip.alpha = 1
             }
-
-            photoImageView.snp.remakeConstraints { make in
-                make.top.equalTo(customNavigationBar.snp.bottom).offset(66)
-                make.horizontalEdges.equalToSuperview().inset(40)
-                make.bottom.equalTo(toolBarContainer.snp.top).offset(-48)
-            }
-
-            UIView.animate(withDuration: 0.3, animations: {
-                self.view.layoutIfNeeded()
-            }, completion: { _ in
-                self.adjustStickerPositions()
-                self.updateUndoRedoButtons()
-            })
-
-            toolPicker.setVisible(true, forFirstResponder: canvasView)
+            updateUndoRedoButtons()
         case .filter:
             photoImageView.snp.remakeConstraints { make in
                 make.top.equalTo(customNavigationBar.snp.bottom).offset(40)

--- a/Sahara/Feature/MediaEditor/MediaEditorViewController+UI.swift
+++ b/Sahara/Feature/MediaEditor/MediaEditorViewController+UI.swift
@@ -96,6 +96,7 @@ extension MediaEditorViewController {
         view.addSubview(cropOverlayView)
         view.addSubview(cropApplyButton)
         view.addSubview(cropCancelButton)
+        view.addSubview(drawingToolStrip)
         view.addSubview(undoButton)
         view.addSubview(redoButton)
 
@@ -170,6 +171,13 @@ extension MediaEditorViewController {
         cropDimOverlay.snp.makeConstraints { make in
             make.edges.equalToSuperview()
         }
+
+        drawingToolStrip.snp.makeConstraints { make in
+            make.leading.trailing.equalToSuperview().inset(16)
+            make.bottom.equalTo(toolBarContainer.snp.top).offset(-8)
+            make.height.equalTo(88)
+        }
+        drawingToolStrip.isHidden = true
 
         undoButton.snp.makeConstraints { make in
             make.trailing.equalTo(view.snp.centerX).offset(-4)

--- a/Sahara/Feature/MediaEditor/MediaEditorViewController.swift
+++ b/Sahara/Feature/MediaEditor/MediaEditorViewController.swift
@@ -249,7 +249,7 @@ final class MediaEditorViewController: UIViewController {
     private let disposeBag = DisposeBag()
 
     let currentMode = BehaviorRelay<EditMode?>(value: nil)
-    let toolPicker = PKToolPicker()
+    let drawingToolStrip = DrawingToolStrip()
 
     private var stickerViews: [DraggableStickerView] = []
     private var photoViews: [DraggableImageView] = []
@@ -313,13 +313,29 @@ final class MediaEditorViewController: UIViewController {
     private func setupPencilKit() {
         canvasView.tool = PKInkingTool(.pen, color: .black, width: 5)
         canvasView.delegate = self
+        setupDrawingToolStrip()
+    }
 
-        toolPicker.setVisible(false, forFirstResponder: canvasView)
-        toolPicker.addObserver(canvasView)
-        canvasView.becomeFirstResponder()
+    private func setupDrawingToolStrip() {
+        drawingToolStrip.onToolChanged = { [weak self] tool in
+            self?.canvasView.tool = tool
+        }
 
-        if let window = view.window {
-            toolPicker.frameObscured(in: window)
+        drawingToolStrip.onCustomColorRequested = { [weak self] in
+            let picker = UIColorPickerViewController()
+            picker.delegate = self
+            picker.supportsAlpha = false
+            self?.present(picker, animated: true)
+        }
+
+        drawingToolStrip.onUndoTapped = { [weak self] in
+            self?.canvasView.undoManager?.undo()
+            self?.updateUndoRedoButtons()
+        }
+
+        drawingToolStrip.onRedoTapped = { [weak self] in
+            self?.canvasView.undoManager?.redo()
+            self?.updateUndoRedoButtons()
         }
     }
 
@@ -719,11 +735,9 @@ final class MediaEditorViewController: UIViewController {
     func updateUndoRedoButtons() {
         guard currentMode.value == .drawing else { return }
 
-        undoButton.isEnabled = canvasView.undoManager?.canUndo ?? false
-        redoButton.isEnabled = canvasView.undoManager?.canRedo ?? false
-
-        undoButton.alpha = undoButton.isEnabled ? 1.0 : 0.5
-        redoButton.alpha = redoButton.isEnabled ? 1.0 : 0.5
+        let canUndo = canvasView.undoManager?.canUndo ?? false
+        let canRedo = canvasView.undoManager?.canRedo ?? false
+        drawingToolStrip.updateUndoRedoState(canUndo: canUndo, canRedo: canRedo)
     }
 
     private func selectView(_ view: BaseGestureView) {
@@ -1002,5 +1016,12 @@ extension MediaEditorViewController: PKCanvasViewDelegate {
 extension MediaEditorViewController: UIGestureRecognizerDelegate {
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
         return true
+    }
+}
+
+extension MediaEditorViewController: UIColorPickerViewControllerDelegate {
+    func colorPickerViewController(_ viewController: UIColorPickerViewController, didSelect color: UIColor, continuously: Bool) {
+        guard !continuously else { return }
+        drawingToolStrip.updateColor(color)
     }
 }

--- a/Sahara/Feature/MediaEditor/Model/DrawingTool.swift
+++ b/Sahara/Feature/MediaEditor/Model/DrawingTool.swift
@@ -1,0 +1,74 @@
+//
+//  DrawingTool.swift
+//  Sahara
+//
+//  Created by 금가경 on 3/25/26.
+//
+
+import PencilKit
+import UIKit
+
+enum DrawingTool: CaseIterable {
+    case pen
+    case pencil
+    case marker
+    case fountainPen
+    case watercolor
+    case crayon
+    case monoline
+    case eraser
+    case lasso
+
+    var inkType: PKInkingTool.InkType? {
+        switch self {
+        case .pen:         return .pen
+        case .pencil:      return .pencil
+        case .marker:      return .marker
+        case .fountainPen: return .fountainPen
+        case .watercolor:  return .watercolor
+        case .crayon:      return .crayon
+        case .monoline:    return .monoline
+        case .eraser:      return nil
+        case .lasso:       return nil
+        }
+    }
+
+    var iconName: String {
+        switch self {
+        case .pen:         return "pencil.tip"
+        case .pencil:      return "pencil"
+        case .marker:      return "highlighter"
+        case .fountainPen: return "paintbrush.pointed"
+        case .watercolor:  return "paintbrush"
+        case .crayon:      return "scribble"
+        case .monoline:    return "line.diagonal"
+        case .eraser:      return "eraser"
+        case .lasso:       return "lasso"
+        }
+    }
+
+    var localizedName: String {
+        switch self {
+        case .pen:         return NSLocalizedString("media_editor.tool.pen", comment: "")
+        case .pencil:      return NSLocalizedString("media_editor.tool.pencil", comment: "")
+        case .marker:      return NSLocalizedString("media_editor.tool.marker", comment: "")
+        case .fountainPen: return NSLocalizedString("media_editor.tool.fountain_pen", comment: "")
+        case .watercolor:  return NSLocalizedString("media_editor.tool.watercolor", comment: "")
+        case .crayon:      return NSLocalizedString("media_editor.tool.crayon", comment: "")
+        case .monoline:    return NSLocalizedString("media_editor.tool.monoline", comment: "")
+        case .eraser:      return NSLocalizedString("media_editor.tool.eraser", comment: "")
+        case .lasso:       return NSLocalizedString("media_editor.tool.lasso", comment: "")
+        }
+    }
+
+    func pkTool(color: UIColor, width: CGFloat) -> PKTool {
+        switch self {
+        case .lasso:
+            return PKLassoTool()
+        case .eraser:
+            return PKEraserTool(.bitmap)
+        default:
+            return PKInkingTool(inkType!, color: color, width: width)
+        }
+    }
+}

--- a/Sahara/Feature/MediaEditor/View/DrawingToolStrip.swift
+++ b/Sahara/Feature/MediaEditor/View/DrawingToolStrip.swift
@@ -1,0 +1,359 @@
+//
+//  DrawingToolStrip.swift
+//  Sahara
+//
+//  Created by 금가경 on 3/25/26.
+//
+
+import PencilKit
+import SnapKit
+import UIKit
+
+final class DrawingToolStrip: UIView {
+
+    // MARK: - Callbacks
+
+    var onToolChanged: ((PKTool) -> Void)?
+    var onCustomColorRequested: (() -> Void)?
+    var onUndoTapped: (() -> Void)?
+    var onRedoTapped: (() -> Void)?
+
+    // MARK: - State
+
+    private var selectedTool: DrawingTool = .pen
+    private var selectedColor: UIColor = .black
+    private var lineWidth: CGFloat = 5
+
+    // MARK: - Constants
+
+    private let colorPresets: [UIColor] = [
+        .black, .white, .systemRed, .systemOrange,
+        .systemYellow, .systemGreen, .systemBlue, .systemPurple
+    ]
+
+    // MARK: - UI (Top Row — Colors)
+
+    private let topRowStack: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.alignment = .center
+        stack.spacing = 6
+        return stack
+    }()
+
+    // MARK: - UI (Bottom Row — Undo/Redo + Slider + Tools)
+
+    private let bottomScrollView: UIScrollView = {
+        let sv = UIScrollView()
+        sv.showsHorizontalScrollIndicator = false
+        sv.showsVerticalScrollIndicator = false
+        return sv
+    }()
+
+    private let bottomRowStack: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.alignment = .center
+        stack.spacing = 10
+        return stack
+    }()
+
+    private let toolStack: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.spacing = 2
+        return stack
+    }()
+
+    private let widthSlider: UISlider = {
+        let slider = UISlider()
+        slider.minimumValue = 1
+        slider.maximumValue = 20
+        slider.value = 5
+        slider.minimumTrackTintColor = .black
+        return slider
+    }()
+
+    private let undoButton: UIButton = {
+        let button = UIButton()
+        var config = UIButton.Configuration.plain()
+        config.image = UIImage(systemName: "arrow.uturn.backward")?
+            .withConfiguration(UIImage.SymbolConfiguration(pointSize: 14, weight: .medium))
+        config.baseForegroundColor = .black
+        config.contentInsets = NSDirectionalEdgeInsets(top: 6, leading: 6, bottom: 6, trailing: 6)
+        button.configuration = config
+        button.isEnabled = false
+        button.alpha = 0.3
+        return button
+    }()
+
+    private let redoButton: UIButton = {
+        let button = UIButton()
+        var config = UIButton.Configuration.plain()
+        config.image = UIImage(systemName: "arrow.uturn.forward")?
+            .withConfiguration(UIImage.SymbolConfiguration(pointSize: 14, weight: .medium))
+        config.baseForegroundColor = .black
+        config.contentInsets = NSDirectionalEdgeInsets(top: 6, leading: 6, bottom: 6, trailing: 6)
+        button.configuration = config
+        button.isEnabled = false
+        button.alpha = 0.3
+        return button
+    }()
+
+    private var toolButtons: [UIButton] = []
+    private var colorButtons: [UIButton] = []
+
+    // MARK: - Init
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+        selectTool(.pen)
+        selectColorButton(at: 0)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Public
+
+    func updateColor(_ color: UIColor) {
+        selectedColor = color
+        deselectAllColorButtons()
+        notifyToolChanged()
+    }
+
+    func updateUndoRedoState(canUndo: Bool, canRedo: Bool) {
+        undoButton.isEnabled = canUndo
+        undoButton.alpha = canUndo ? 1.0 : 0.3
+        redoButton.isEnabled = canRedo
+        redoButton.alpha = canRedo ? 1.0 : 0.3
+    }
+
+    // MARK: - Setup
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        applyGradient(.tabBar)
+    }
+
+    private func setupUI() {
+        layer.cornerRadius = DesignToken.CornerRadius.card
+        clipsToBounds = true
+
+        let rootStack = UIStackView()
+        rootStack.axis = .vertical
+        rootStack.spacing = 6
+
+        addSubview(rootStack)
+        rootStack.snp.makeConstraints { make in
+            make.edges.equalToSuperview().inset(UIEdgeInsets(top: 8, left: 12, bottom: 8, right: 12))
+        }
+
+        setupTopRow()
+        setupBottomRow()
+
+        rootStack.addArrangedSubview(topRowStack)
+        rootStack.addArrangedSubview(bottomScrollView)
+    }
+
+    // MARK: - Top Row (Colors)
+
+    private func setupTopRow() {
+        for (index, color) in colorPresets.enumerated() {
+            let button = makeColorButton(color: color)
+            button.tag = index
+            button.addTarget(self, action: #selector(colorButtonTapped(_:)), for: .touchUpInside)
+            colorButtons.append(button)
+            topRowStack.addArrangedSubview(button)
+        }
+
+        let customButton = UIButton()
+        var config = UIButton.Configuration.plain()
+        config.image = UIImage(systemName: "plus.circle.fill")?
+            .withConfiguration(UIImage.SymbolConfiguration(pointSize: 18))
+        config.baseForegroundColor = UIColor.black.withAlphaComponent(0.5)
+        config.contentInsets = NSDirectionalEdgeInsets(top: 2, leading: 2, bottom: 2, trailing: 2)
+        customButton.configuration = config
+
+        customButton.snp.makeConstraints { make in
+            make.width.height.equalTo(26)
+        }
+
+        customButton.addTarget(self, action: #selector(customColorTapped), for: .touchUpInside)
+        topRowStack.addArrangedSubview(customButton)
+
+        let spacer = UIView()
+        topRowStack.addArrangedSubview(spacer)
+    }
+
+    // MARK: - Bottom Row (Undo/Redo + Slider + Tools)
+
+    private func setupBottomRow() {
+        bottomScrollView.addSubview(bottomRowStack)
+
+        bottomRowStack.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+            make.height.equalToSuperview()
+        }
+
+        setupUndoRedoButtons()
+        setupSeparator()
+        setupWidthSlider()
+        setupSeparator()
+        setupToolButtons()
+    }
+
+    private func setupUndoRedoButtons() {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.spacing = 2
+
+        undoButton.snp.makeConstraints { make in
+            make.width.height.equalTo(32)
+        }
+        redoButton.snp.makeConstraints { make in
+            make.width.height.equalTo(32)
+        }
+
+        undoButton.addTarget(self, action: #selector(undoTapped), for: .touchUpInside)
+        redoButton.addTarget(self, action: #selector(redoTapped), for: .touchUpInside)
+
+        stack.addArrangedSubview(undoButton)
+        stack.addArrangedSubview(redoButton)
+        bottomRowStack.addArrangedSubview(stack)
+    }
+
+    private func setupWidthSlider() {
+        widthSlider.addTarget(self, action: #selector(sliderChanged(_:)), for: .valueChanged)
+
+        widthSlider.snp.makeConstraints { make in
+            make.width.equalTo(100)
+        }
+
+        bottomRowStack.addArrangedSubview(widthSlider)
+    }
+
+    private func setupToolButtons() {
+        for tool in DrawingTool.allCases {
+            let button = UIButton()
+            var config = UIButton.Configuration.plain()
+            config.image = UIImage(systemName: tool.iconName)?
+                .withConfiguration(UIImage.SymbolConfiguration(pointSize: 16, weight: .medium))
+            config.baseForegroundColor = .black
+            config.contentInsets = NSDirectionalEdgeInsets(top: 6, leading: 6, bottom: 6, trailing: 6)
+            button.configuration = config
+            button.alpha = 0.5
+
+            button.snp.makeConstraints { make in
+                make.width.height.equalTo(36)
+            }
+
+            button.addTarget(self, action: #selector(toolButtonTapped(_:)), for: .touchUpInside)
+            toolButtons.append(button)
+            toolStack.addArrangedSubview(button)
+        }
+
+        bottomRowStack.addArrangedSubview(toolStack)
+    }
+
+    private func setupSeparator() {
+        let separator = UIView()
+        separator.backgroundColor = UIColor.black.withAlphaComponent(0.15)
+
+        separator.snp.makeConstraints { make in
+            make.width.equalTo(1)
+            make.height.equalTo(24)
+        }
+
+        bottomRowStack.addArrangedSubview(separator)
+    }
+
+    private func makeColorButton(color: UIColor) -> UIButton {
+        let button = UIButton()
+        button.backgroundColor = color
+        button.layer.cornerRadius = 11
+        button.layer.borderWidth = 2
+        button.layer.borderColor = UIColor.clear.cgColor
+        button.clipsToBounds = true
+
+        if color == .white {
+            button.layer.borderColor = UIColor.black.withAlphaComponent(0.15).cgColor
+        }
+
+        button.snp.makeConstraints { make in
+            make.width.height.equalTo(22)
+        }
+
+        return button
+    }
+
+    // MARK: - Actions
+
+    @objc private func undoTapped() {
+        onUndoTapped?()
+    }
+
+    @objc private func redoTapped() {
+        onRedoTapped?()
+    }
+
+    @objc private func toolButtonTapped(_ sender: UIButton) {
+        guard let index = toolButtons.firstIndex(of: sender) else { return }
+        let tool = DrawingTool.allCases[index]
+        selectTool(tool)
+        notifyToolChanged()
+    }
+
+    @objc private func colorButtonTapped(_ sender: UIButton) {
+        selectColorButton(at: sender.tag)
+        selectedColor = colorPresets[sender.tag]
+        notifyToolChanged()
+    }
+
+    @objc private func customColorTapped() {
+        onCustomColorRequested?()
+    }
+
+    @objc private func sliderChanged(_ sender: UISlider) {
+        lineWidth = CGFloat(sender.value)
+        notifyToolChanged()
+    }
+
+    // MARK: - Selection
+
+    private func selectTool(_ tool: DrawingTool) {
+        selectedTool = tool
+
+        for (index, button) in toolButtons.enumerated() {
+            let isSelected = DrawingTool.allCases[index] == tool
+            button.alpha = isSelected ? 1.0 : 0.5
+        }
+    }
+
+    private func selectColorButton(at index: Int) {
+        deselectAllColorButtons()
+
+        guard index < colorButtons.count else { return }
+        let button = colorButtons[index]
+        button.layer.borderColor = UIColor.black.cgColor
+    }
+
+    private func deselectAllColorButtons() {
+        for (index, button) in colorButtons.enumerated() {
+            if colorPresets[index] == .white {
+                button.layer.borderColor = UIColor.black.withAlphaComponent(0.15).cgColor
+            } else {
+                button.layer.borderColor = UIColor.clear.cgColor
+            }
+        }
+    }
+
+    // MARK: - Notify
+
+    private func notifyToolChanged() {
+        let tool = selectedTool.pkTool(color: selectedColor, width: lineWidth)
+        onToolChanged?(tool)
+    }
+}

--- a/Sahara/Resources/en.lproj/Localizable.strings
+++ b/Sahara/Resources/en.lproj/Localizable.strings
@@ -110,6 +110,15 @@
 "media_editor.sticker_modal_title" = "Stickers";
 "media_editor.undo" = "Undo";
 "media_editor.redo" = "Redo";
+"media_editor.tool.pen" = "Pen";
+"media_editor.tool.pencil" = "Pencil";
+"media_editor.tool.marker" = "Marker";
+"media_editor.tool.fountain_pen" = "Fountain Pen";
+"media_editor.tool.watercolor" = "Watercolor";
+"media_editor.tool.crayon" = "Crayon";
+"media_editor.tool.monoline" = "Monoline";
+"media_editor.tool.eraser" = "Eraser";
+"media_editor.tool.lasso" = "Lasso";
 "media_editor.network_error" = "Unable to connect to network";
 
 /* Filters */

--- a/Sahara/Resources/ja.lproj/Localizable.strings
+++ b/Sahara/Resources/ja.lproj/Localizable.strings
@@ -110,6 +110,15 @@
 "media_editor.sticker_modal_title" = "ステッカー";
 "media_editor.undo" = "元に戻す";
 "media_editor.redo" = "やり直し";
+"media_editor.tool.pen" = "ペン";
+"media_editor.tool.pencil" = "鉛筆";
+"media_editor.tool.marker" = "マーカー";
+"media_editor.tool.fountain_pen" = "万年筆";
+"media_editor.tool.watercolor" = "水彩";
+"media_editor.tool.crayon" = "クレヨン";
+"media_editor.tool.monoline" = "モノライン";
+"media_editor.tool.eraser" = "消しゴム";
+"media_editor.tool.lasso" = "選択";
 "media_editor.network_error" = "ネットワークに接続できません";
 
 /* Filters */

--- a/Sahara/Resources/ko.lproj/Localizable.strings
+++ b/Sahara/Resources/ko.lproj/Localizable.strings
@@ -110,6 +110,15 @@
 "media_editor.sticker_modal_title" = "스티커";
 "media_editor.undo" = "실행 취소";
 "media_editor.redo" = "다시 실행";
+"media_editor.tool.pen" = "펜";
+"media_editor.tool.pencil" = "연필";
+"media_editor.tool.marker" = "마커";
+"media_editor.tool.fountain_pen" = "만년필";
+"media_editor.tool.watercolor" = "수채화";
+"media_editor.tool.crayon" = "크레용";
+"media_editor.tool.monoline" = "모노라인";
+"media_editor.tool.eraser" = "지우개";
+"media_editor.tool.lasso" = "선택";
 "media_editor.network_error" = "네트워크에 연결할 수 없어요";
 
 /* Filters */

--- a/Sahara/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sahara/Resources/zh-Hans.lproj/Localizable.strings
@@ -110,6 +110,15 @@
 "media_editor.sticker_modal_title" = "贴纸";
 "media_editor.undo" = "撤销";
 "media_editor.redo" = "重做";
+"media_editor.tool.pen" = "钢笔";
+"media_editor.tool.pencil" = "铅笔";
+"media_editor.tool.marker" = "马克笔";
+"media_editor.tool.fountain_pen" = "钢笔";
+"media_editor.tool.watercolor" = "水彩";
+"media_editor.tool.crayon" = "蜡笔";
+"media_editor.tool.monoline" = "等线笔";
+"media_editor.tool.eraser" = "橡皮擦";
+"media_editor.tool.lasso" = "套索";
 "media_editor.network_error" = "无法连接到网络";
 
 /* Filters */


### PR DESCRIPTION
Closes #75

## 변경 내용

**추가**
- 커스텀 드로잉 도구 모델 (펜, 연필, 마커, 만년필, 수채화, 크레용, 모노라인, 지우개, 올가미)
- 커스텀 드로잉 도구 바 UI (색상 프리셋, 선 굵기 슬라이더, 도구 선택, 실행취소/다시실행)
- 드로잉 도구 이름 다국어 지원 (ko/en/ja/zh-Hans)
- 컬러 피커를 통한 커스텀 색상 선택 기능

**제거**
- 기본 PKToolPicker 의존성

**수정**
- 갤러리 및 캘린더 헤더의 그라데이션 스타일을 tabBar로 통일

## 결정 근거

- **PKToolPicker → 커스텀 UI** — 기본 DrawingKit 도구 바가 탭바를 가려서 탭바 위치를 위로 올려야 했음. 일관적인 탭바 위치를 유지하기 위해 커스텀 도구 바로 전환