### PR TITLE
Fix editor canvas to static layout with styled tool panels

### DIFF
--- a/Sahara/Feature/MediaEditor/MediaEditorViewController+Mode.swift
+++ b/Sahara/Feature/MediaEditor/MediaEditorViewController+Mode.swift
@@ -28,32 +28,6 @@ extension MediaEditorViewController {
         undoButton.isHidden = true
         redoButton.isHidden = true
 
-        photoImageView.snp.remakeConstraints { make in
-            make.top.equalTo(customNavigationBar.snp.bottom).offset(40)
-            make.horizontalEdges.equalToSuperview().inset(40)
-            make.bottom.equalTo(toolBarContainer.snp.top).offset(-48)
-        }
-
-        stickerContainerView.snp.remakeConstraints { make in
-            make.edges.equalTo(photoImageView)
-        }
-
-        canvasView.snp.remakeConstraints { make in
-            make.edges.equalTo(photoImageView)
-        }
-
-        toolBarContainer.snp.remakeConstraints { make in
-            make.leading.trailing.equalToSuperview()
-            make.bottom.equalToSuperview()
-            make.height.equalTo(88)
-        }
-
-        UIView.animate(withDuration: 0.3, animations: {
-            self.view.layoutIfNeeded()
-        }, completion: { _ in
-            self.adjustStickerPositions()
-        })
-
         guard let mode = mode else {
             doneButton.isHidden = false
             doneButton.isEnabled = true
@@ -74,21 +48,8 @@ extension MediaEditorViewController {
             }
             updateUndoRedoButtons()
         case .filter:
-            photoImageView.snp.remakeConstraints { make in
-                make.top.equalTo(customNavigationBar.snp.bottom).offset(40)
-                make.horizontalEdges.equalToSuperview().inset(40)
-                make.bottom.equalTo(filterCollectionView.snp.top).offset(-16)
-            }
-
             filterCollectionView.isHidden = false
-
-            UIView.animate(withDuration: 0.3, animations: {
-                self.view.layoutIfNeeded()
-            }, completion: { _ in
-                self.adjustStickerPositions()
-                self.filterCollectionView.reloadData()
-                self.filterCollectionView.layoutIfNeeded()
-            })
+            filterCollectionView.reloadData()
         case .photo:
             presentPhotoSelectionModal()
         case .crop:
@@ -100,26 +61,6 @@ extension MediaEditorViewController {
             cancelButton.isHidden = true
             doneButton.isHidden = true
 
-            cropCancelButton.snp.remakeConstraints { make in
-                make.leading.equalToSuperview().inset(20)
-                make.top.equalTo(view.safeAreaLayoutGuide).offset(20)
-                make.width.greaterThanOrEqualTo(80)
-                make.height.equalTo(44)
-            }
-
-            cropApplyButton.snp.remakeConstraints { make in
-                make.trailing.equalToSuperview().inset(20)
-                make.top.equalTo(view.safeAreaLayoutGuide).offset(20)
-                make.width.greaterThanOrEqualTo(80)
-                make.height.equalTo(44)
-            }
-
-            photoImageView.snp.remakeConstraints { make in
-                make.top.equalTo(cropCancelButton.snp.bottom).offset(40)
-                make.horizontalEdges.equalToSuperview().inset(20)
-                make.bottom.equalTo(view.safeAreaLayoutGuide).offset(-40)
-            }
-
             cropOverlayView.isHidden = false
             cropApplyButton.isHidden = false
             cropCancelButton.isHidden = false
@@ -127,12 +68,8 @@ extension MediaEditorViewController {
             guard let uncropped = cachedUncroppedOriginalImage else { return }
             photoImageView.image = uncropped
 
-            UIView.animate(withDuration: 0.3, animations: {
-                self.view.layoutIfNeeded()
-            }, completion: { _ in
-                self.adjustStickerPositions()
-                self.setupCropOverlay()
-            })
+            view.layoutIfNeeded()
+            setupCropOverlay()
         }
     }
 

--- a/Sahara/Feature/MediaEditor/MediaEditorViewController+Mode.swift
+++ b/Sahara/Feature/MediaEditor/MediaEditorViewController+Mode.swift
@@ -10,7 +10,7 @@ import UIKit
 
 extension MediaEditorViewController {
     func updateEditMode(mode: EditMode?) {
-        filterCollectionView.isHidden = true
+        filterContainerView.isHidden = true
         drawingToolStrip.isHidden = true
         canvasView.isUserInteractionEnabled = false
         photoImageView.isUserInteractionEnabled = false
@@ -48,7 +48,7 @@ extension MediaEditorViewController {
             }
             updateUndoRedoButtons()
         case .filter:
-            filterCollectionView.isHidden = false
+            filterContainerView.isHidden = false
             filterCollectionView.reloadData()
         case .photo:
             presentPhotoSelectionModal()

--- a/Sahara/Feature/MediaEditor/MediaEditorViewController+UI.swift
+++ b/Sahara/Feature/MediaEditor/MediaEditorViewController+UI.swift
@@ -89,7 +89,8 @@ extension MediaEditorViewController {
         view.addSubview(stickerContainerView)
         view.addSubview(canvasView)
         view.addSubview(toolBarContainer)
-        view.addSubview(filterCollectionView)
+        view.addSubview(filterContainerView)
+        filterContainerView.addSubview(filterCollectionView)
         view.addSubview(trashIconView)
         view.addSubview(leftStarImageView)
         view.addSubview(rightStarImageView)
@@ -127,9 +128,9 @@ extension MediaEditorViewController {
         }
 
         photoImageView.snp.makeConstraints { make in
-            make.top.equalTo(customNavigationBar.snp.bottom).offset(40)
+            make.top.equalTo(customNavigationBar.snp.bottom).offset(20)
             make.horizontalEdges.equalToSuperview().inset(40)
-            make.bottom.equalTo(toolBarContainer.snp.top).offset(-48)
+            make.bottom.equalTo(drawingToolStrip.snp.top).offset(-20)
         }
 
 
@@ -141,10 +142,14 @@ extension MediaEditorViewController {
             make.edges.equalTo(photoImageView)
         }
 
-        filterCollectionView.snp.makeConstraints { make in
+        filterContainerView.applyGradient(.tabBar)
+        filterContainerView.snp.makeConstraints { make in
+            make.horizontalEdges.equalToSuperview().inset(16)
             make.bottom.equalTo(toolBarContainer.snp.top).offset(-28)
-            make.horizontalEdges.equalToSuperview().inset(40)
             make.height.equalTo(144)
+        }
+        filterCollectionView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
         }
 
         trashIconView.snp.makeConstraints { make in
@@ -173,9 +178,9 @@ extension MediaEditorViewController {
         }
 
         drawingToolStrip.snp.makeConstraints { make in
-            make.leading.trailing.equalToSuperview().inset(16)
-            make.bottom.equalTo(toolBarContainer.snp.top).offset(-8)
-            make.height.equalTo(88)
+            make.horizontalEdges.equalToSuperview().inset(16)
+            make.bottom.equalTo(toolBarContainer.snp.top).offset(-28)
+            make.height.equalTo(144)
         }
         drawingToolStrip.isHidden = true
 

--- a/Sahara/Feature/MediaEditor/MediaEditorViewController.swift
+++ b/Sahara/Feature/MediaEditor/MediaEditorViewController.swift
@@ -194,6 +194,14 @@ final class MediaEditorViewController: UIViewController {
         return button
     }()
 
+    let filterContainerView: UIView = {
+        let view = UIView()
+        view.layer.cornerRadius = DesignToken.CornerRadius.card
+        view.clipsToBounds = true
+        view.isHidden = true
+        return view
+    }()
+
     lazy var filterCollectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
@@ -202,12 +210,10 @@ final class MediaEditorViewController: UIViewController {
         layout.sectionInset = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
 
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
-        collectionView.backgroundColor = .token(.backgroundCard)
+        collectionView.backgroundColor = .clear
         collectionView.showsHorizontalScrollIndicator = false
         collectionView.register(FilterCell.self, forCellWithReuseIdentifier: FilterCell.identifier)
         collectionView.dataSource = self
-        collectionView.layer.cornerRadius = 12
-        collectionView.clipsToBounds = true
         return collectionView
     }()
 

--- a/Sahara/Feature/MediaEditor/MediaEditorViewController.swift
+++ b/Sahara/Feature/MediaEditor/MediaEditorViewController.swift
@@ -254,7 +254,6 @@ final class MediaEditorViewController: UIViewController {
     private var stickerViews: [DraggableStickerView] = []
     private var photoViews: [DraggableImageView] = []
     private var selectedView: BaseGestureView?
-    private var lastContainerSize: CGSize = .zero
 
     var cachedUncroppedOriginalImage: UIImage?
     var lastCropRect: CGRect?
@@ -672,53 +671,6 @@ final class MediaEditorViewController: UIViewController {
 
         photoViews.append(imageView)
         selectView(imageView)
-    }
-
-    func adjustStickerPositions() {
-        view.layoutIfNeeded()
-
-        guard lastContainerSize.width > 0, lastContainerSize.height > 0,
-              stickerContainerView.bounds.width > 0, stickerContainerView.bounds.height > 0 else {
-            lastContainerSize = stickerContainerView.bounds.size
-            return
-        }
-
-        let scaleX = stickerContainerView.bounds.width / lastContainerSize.width
-        let scaleY = stickerContainerView.bounds.height / lastContainerSize.height
-
-        guard scaleX != 1.0 || scaleY != 1.0 else {
-            return
-        }
-
-        adjustViewsWithScale(scaleX: scaleX, scaleY: scaleY)
-        adjustDrawingWithScale(scaleX: scaleX, scaleY: scaleY)
-
-        lastContainerSize = stickerContainerView.bounds.size
-    }
-
-    private func adjustViewsWithScale(scaleX: CGFloat, scaleY: CGFloat) {
-        UIView.animate(withDuration: 0.3) {
-            self.stickerViews.forEach { view in
-                view.center = CGPoint(
-                    x: view.center.x * scaleX,
-                    y: view.center.y * scaleY
-                )
-            }
-
-            self.photoViews.forEach { view in
-                view.center = CGPoint(
-                    x: view.center.x * scaleX,
-                    y: view.center.y * scaleY
-                )
-            }
-        }
-    }
-
-    private func adjustDrawingWithScale(scaleX: CGFloat, scaleY: CGFloat) {
-        guard !canvasView.drawing.strokes.isEmpty else { return }
-
-        let scaleTransform = CGAffineTransform(scaleX: scaleX, y: scaleY)
-        canvasView.drawing = canvasView.drawing.transformed(using: scaleTransform)
     }
 
     private func generateFinalImage() -> UIImage {

--- a/Sahara/Feature/MediaEditor/View/DrawingToolStrip.swift
+++ b/Sahara/Feature/MediaEditor/View/DrawingToolStrip.swift
@@ -136,6 +136,19 @@ final class DrawingToolStrip: UIView {
     override func layoutSubviews() {
         super.layoutSubviews()
         applyGradient(.tabBar)
+
+        let contentWidth = bottomScrollView.contentSize.width
+        let scrollWidth = bottomScrollView.bounds.width
+        let newInset: UIEdgeInsets
+        if contentWidth > 0, contentWidth < scrollWidth {
+            let horizontal = (scrollWidth - contentWidth) / 2
+            newInset = UIEdgeInsets(top: 0, left: horizontal, bottom: 0, right: horizontal)
+        } else {
+            newInset = .zero
+        }
+        if bottomScrollView.contentInset != newInset {
+            bottomScrollView.contentInset = newInset
+        }
     }
 
     private func setupUI() {
@@ -145,10 +158,12 @@ final class DrawingToolStrip: UIView {
         let rootStack = UIStackView()
         rootStack.axis = .vertical
         rootStack.spacing = 6
+        rootStack.alignment = .center
 
         addSubview(rootStack)
         rootStack.snp.makeConstraints { make in
-            make.edges.equalToSuperview().inset(UIEdgeInsets(top: 8, left: 12, bottom: 8, right: 12))
+            make.horizontalEdges.equalToSuperview().inset(12)
+            make.centerY.equalToSuperview()
         }
 
         setupTopRow()
@@ -156,6 +171,10 @@ final class DrawingToolStrip: UIView {
 
         rootStack.addArrangedSubview(topRowStack)
         rootStack.addArrangedSubview(bottomScrollView)
+
+        bottomScrollView.snp.makeConstraints { make in
+            make.width.equalTo(rootStack)
+        }
     }
 
     // MARK: - Top Row (Colors)
@@ -184,8 +203,6 @@ final class DrawingToolStrip: UIView {
         customButton.addTarget(self, action: #selector(customColorTapped), for: .touchUpInside)
         topRowStack.addArrangedSubview(customButton)
 
-        let spacer = UIView()
-        topRowStack.addArrangedSubview(spacer)
     }
 
     // MARK: - Bottom Row (Undo/Redo + Slider + Tools)


### PR DESCRIPTION
Closes #77

## 변경 내용

**추가**
- 필터 컬렉션뷰에 그라데이션 스타일 컨테이너 적용 (그리기 도구 패널과 동일한 시각 처리)
- 그리기 도구 패널의 색상 행/도구 행을 수직·수평 가운데 정렬

**제거**
- 모드 전환 시 동적 제약 재설정 로직 전체 삭제
- 스티커/드로잉 위치 비례 스케일링 코드 삭제

**수정**
- 사진 영역을 navbar 하단 ~ 도구 패널 상단 사이에 고정 배치 (모든 모드에서 위치 불변)
- 자르기 모드에서 사진 크기를 변경하지 않고 기존 영역 위에 오버레이 방식으로 처리

## 결정 근거

- **정적 레이아웃** — 모드마다 이미지 크기가 변동되면 스티커/드로잉 위치에 누적 오차가 발생함. 고정하면 오차 자체가 없어짐
- **스케일링 코드 삭제** — 레이아웃이 고정되면 비례 스케일링이 불필요하므로 복잡도만 증가시키는 코드 제거
- **contentInset 가드** — layoutSubviews에서 스크롤뷰 센터링 시 값 변경이 없으면 설정을 건너뛰어 레이아웃 루프 방지