### PR TITLE
Fix date change causing card duplication via iCloud sync

### DIFF
--- a/Sahara/Common/Service/Sync/CloudSyncService.swift
+++ b/Sahara/Common/Service/Sync/CloudSyncService.swift
@@ -219,7 +219,9 @@ final class CloudSyncService: CloudSyncServiceProtocol {
                 for index in insertions {
                     let card = collection[index]
                     let cardId = card.id.stringValue
-                    if !self.removeRemoteModifiedId(cardId) {
+                    if self.removeRemoteModifiedId(cardId) {
+                        self.logger.debug("Skipped echo-back for inserted \(cardId)")
+                    } else {
                         self.notifyChange(recordID: cardId, type: .save)
                     }
                 }

--- a/Sahara/Common/Service/Sync/CloudSyncService.swift
+++ b/Sahara/Common/Service/Sync/CloudSyncService.swift
@@ -215,7 +215,14 @@ final class CloudSyncService: CloudSyncServiceProtocol {
             guard let self else { return }
 
             switch changes {
-            case .update(let collection, _, _, let modifications):
+            case .update(let collection, let deletions, let insertions, let modifications):
+                for index in insertions {
+                    let card = collection[index]
+                    let cardId = card.id.stringValue
+                    if !self.removeRemoteModifiedId(cardId) {
+                        self.notifyChange(recordID: cardId, type: .save)
+                    }
+                }
                 for index in modifications {
                     let card = collection[index]
                     let cardId = card.id.stringValue
@@ -224,6 +231,9 @@ final class CloudSyncService: CloudSyncServiceProtocol {
                     } else {
                         self.notifyChange(recordID: cardId, type: .save)
                     }
+                }
+                if !deletions.isEmpty {
+                    self.logger.warning("Realm observer: \(deletions.count) deletion(s) without explicit sync")
                 }
             case .initial, .error:
                 break

--- a/Sahara/Feature/CardInfo/CardInfoViewModel.swift
+++ b/Sahara/Feature/CardInfo/CardInfoViewModel.swift
@@ -181,13 +181,8 @@ final class CardInfoViewModel: BaseViewModelProtocol {
             let shouldPop = shouldPopToList(newDate: date, newLocation: location)
             shouldPopToListRelay.accept(shouldPop)
 
-            if shouldPop {
-                return replaceCardObservable(cardId: cardId, date: date, memo: memo, customFolder: customFolder, location: location, isLocked: isLocked)
-                    .map { true }
-            } else {
-                return updateCardObservable(cardId: cardId, date: date, memo: memo, customFolder: customFolder, location: location, isLocked: isLocked)
-                    .map { true }
-            }
+            return updateCardObservable(cardId: cardId, date: date, memo: memo, customFolder: customFolder, location: location, isLocked: isLocked)
+                .map { true }
         } else {
             shouldPopToListRelay.accept(false)
             return saveToRealmObservable(date: date, memo: memo, customFolder: customFolder, location: location, isLocked: isLocked)
@@ -492,6 +487,7 @@ final class CardInfoViewModel: BaseViewModelProtocol {
             card.latitude = location?.coordinate.latitude
             card.longitude = location?.coordinate.longitude
             card.ocrText = ocrText
+            card.modifiedDate = Date()
         }
         .do(onNext: {
             if let oldPath = oldImagePath, oldPath != newImagePath {
@@ -527,6 +523,7 @@ final class CardInfoViewModel: BaseViewModelProtocol {
             card.isLocked = isLocked
             card.latitude = location?.coordinate.latitude
             card.longitude = location?.coordinate.longitude
+            card.modifiedDate = Date()
         }
     }
 
@@ -583,91 +580,4 @@ final class CardInfoViewModel: BaseViewModelProtocol {
             }
     }
 
-    private func createNewCardAndReplaceOld(
-        cardId: ObjectId,
-        date: Date,
-        imageData: PreparedImageData,
-        ocrText: String?,
-        visionTags: [VisionTag],
-        memoText: String?,
-        folderText: String?,
-        location: CLLocation?,
-        isLocked: Bool
-    ) -> Observable<(Void, ObjectId)> {
-        let oldImagePath = realmManager.fetchObject(Card.self, forPrimaryKey: cardId)?.imagePath
-
-        let newCard = createCard(
-            date: date,
-            imageData: imageData,
-            ocrText: ocrText,
-            memo: memoText,
-            customFolder: folderText,
-            location: location,
-            isLocked: isLocked
-        )
-        newCard.visionTags.append(objectsIn: visionTags)
-        let newCardId = newCard.id
-
-        Logger.database.notice("Replaced card")
-
-        return realmManager.update { realm in
-            realm.add(newCard)
-            if let cardToDelete = realm.object(ofType: Card.self, forPrimaryKey: cardId) {
-                realm.delete(cardToDelete)
-            }
-        }
-        .map { ((), newCardId) }
-        .do(onNext: { _ in
-            if let oldPath = oldImagePath {
-                ImageFileService.shared.deleteImageFile(at: oldPath)
-            }
-            ThumbnailCache.shared.invalidate(for: cardId)
-            WidgetDataService.shared.refreshWidgetData()
-        })
-    }
-
-    private func replaceCardObservable(cardId: ObjectId, date: Date, memo: String?, customFolder: String?, location: CLLocation?, isLocked: Bool = false) -> Observable<Void> {
-        guard let editedImage = editedImage else { return .empty() }
-        guard let card = realmManager.fetchObject(Card.self, forPrimaryKey: cardId) else { return .empty() }
-
-        let sanitizedFields = sanitizeTextFields(memo: memo, customFolder: customFolder)
-        let analyticsCtx = collectAnalyticsContext()
-
-        let oldLocation = (card.latitude != nil && card.longitude != nil) ? CLLocation(latitude: card.latitude!, longitude: card.longitude!) : nil
-        let editTypes = trackEditTypes(
-            memoText: sanitizedFields.memo,
-            folderText: sanitizedFields.customFolder,
-            oldLocation: oldLocation,
-            newLocation: location,
-            isLocked: isLocked
-        )
-
-        let existingOcrText = imageChanged ? nil : card.ocrText
-        let existingVisionTags = imageChanged ? [] : Array(card.visionTags)
-
-        return prepareImage(from: editedImage)
-            .observe(on: MainScheduler.instance)
-            .flatMap { [weak self] imageData -> Observable<Void> in
-                guard let self = self else { return .empty() }
-
-                return self.createNewCardAndReplaceOld(
-                    cardId: cardId,
-                    date: date,
-                    imageData: imageData,
-                    ocrText: existingOcrText,
-                    visionTags: existingVisionTags,
-                    memoText: sanitizedFields.memo,
-                    folderText: sanitizedFields.customFolder,
-                    location: location,
-                    isLocked: isLocked
-                )
-                .do(onNext: { _, newCardId in
-                    if self.imageChanged {
-                        self.cardPostProcessor.process(cardId: newCardId, imageData: imageData.editedImageData)
-                    }
-                    self.logUpdateAnalytics(editTypes: editTypes, hadLocationBefore: analyticsCtx.hadLocationBefore, location: location)
-                })
-                .map { _, _ in () }
-            }
-    }
 }


### PR DESCRIPTION
Closes #81

## 변경 내용

**수정**
- 날짜 변경 시 카드 저장 방식을 삭제 후 재생성에서 기존 카드 직접 수정으로 전환
- 카드 메타데이터 수정 시 수정일자를 함께 갱신하여 iCloud 동기화가 변경을 감지하도록 수정
- Realm observer에서 삽입된 카드의 echo-back을 감지하고 로깅하도록 수정

**제거**
- 카드 교체(삭제+재생성) 관련 미사용 메서드 삭제

**추가**
- Realm observer에 삽입 이벤트 처리 및 삭제 이벤트 경고 로깅 추가

## 결정 근거

- **in-place update 전환** — delete+create는 CloudKit에서 삭제와 생성이 별도 레코드로 동기화되어, 타이밍에 따라 삭제가 누락되면 카드가 복제됨. 동일 ObjectId를 유지하는 in-place update는 이 문제를 원천 차단함
- **modifiedDate 갱신** — Realm 트랜잭션이 독립적으로 실행되므로 각 저장 경로에서 명시적으로 수정일자를 설정해야 CloudKit이 변경을 감지함