### PR TITLE
Add background theme customization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ iOSInjectionProject/
 GoogleService-Info.plist
 feature-*-plan.md
 firebase-debug.log
+aso/

--- a/Sahara/Common/Component/GradientButton.swift
+++ b/Sahara/Common/Component/GradientButton.swift
@@ -43,11 +43,11 @@ final class GradientButton: UIButton {
         layer.masksToBounds = true
     }
 
-    func setGradient(_ gradient: DesignToken.Gradient, isSelected: Bool = true) {
+    func setGradient(_ gradient: DesignToken.Gradient, isSelected: Bool = true, textColor: UIColor? = nil) {
         currentGradient = gradient
 
         var config = configuration
-        let color: UIColor = isSelected ? .token(.textOnAccent) : .token(.navigationText)
+        let color: UIColor = textColor ?? (isSelected ? .token(.textOnAccent) : .token(.navigationText))
         let attributedTitle = AttributedString(
             titleText,
             attributes: AttributeContainer([

--- a/Sahara/Common/Design/DesignToken+Gradient.swift
+++ b/Sahara/Common/Design/DesignToken+Gradient.swift
@@ -9,7 +9,7 @@ import UIKit
 
 extension DesignToken {
 
-    enum Gradient {
+    enum Gradient: String, CaseIterable {
         case primary
         case tabBar
         case sidebar
@@ -19,6 +19,10 @@ extension DesignToken {
         case warm
         case fresh
         case highlight
+
+        static let backgroundPresets: [Gradient] = [
+            .primary, .warm, .fresh, .subtle, .ctaPink, .ctaBlue, .tabBar, .highlight
+        ]
 
         var colors: [CGColor] {
             switch self {

--- a/Sahara/Common/Extension/UIColor+Hex.swift
+++ b/Sahara/Common/Extension/UIColor+Hex.swift
@@ -21,4 +21,10 @@ extension UIColor {
 
         self.init(red: red, green: green, blue: blue, alpha: alpha)
     }
+
+    func toHex() -> String {
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0
+        getRed(&r, green: &g, blue: &b, alpha: nil)
+        return String(format: "#%02X%02X%02X", Int(r * 255), Int(g * 255), Int(b * 255))
+    }
 }

--- a/Sahara/Common/Extension/UIView+Gradient.swift
+++ b/Sahara/Common/Extension/UIView+Gradient.swift
@@ -6,6 +6,31 @@
 //
 
 import UIKit
+import RxSwift
+import SnapKit
+
+private final class SolidColorBackgroundView: UIView {}
+
+private final class PhotoBackgroundView: UIView {
+    private let imageView: UIImageView = {
+        let iv = UIImageView()
+        iv.contentMode = .scaleAspectFill
+        iv.clipsToBounds = true
+        return iv
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        addSubview(imageView)
+        imageView.snp.makeConstraints { $0.edges.equalToSuperview() }
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    func configure(image: UIImage) {
+        imageView.image = image
+    }
+}
 
 private final class GradientBackgroundView: UIView {
     override class var layerClass: AnyClass { CAGradientLayer.self }
@@ -16,6 +41,14 @@ private final class GradientBackgroundView: UIView {
         gl.locations = gradient.locations
         gl.startPoint = gradient.startPoint
         gl.endPoint = gradient.endPoint
+    }
+
+    func configure(colors: [CGColor]) {
+        let gl = layer as! CAGradientLayer
+        gl.colors = colors
+        gl.locations = [0.0, 1.0]
+        gl.startPoint = CGPoint(x: 0.5, y: 0)
+        gl.endPoint = CGPoint(x: 0.5, y: 1)
     }
 }
 
@@ -58,5 +91,65 @@ extension UIView {
     func applyGradientWithDots(_ gradient: DesignToken.Gradient, dotSize: CGFloat, spacing: CGFloat, dotColor: UIColor) {
         applyGradient(gradient)
         applyDotPattern(dotSize: dotSize, spacing: spacing, color: dotColor)
+    }
+
+    func applyBackgroundConfig(_ config: BackgroundConfig, photoData: Data? = nil) {
+        removeAllBackgroundViews()
+
+        switch config.theme {
+        case .solidColor(let hex):
+            let bgView = SolidColorBackgroundView()
+            bgView.backgroundColor = UIColor(hex: hex)
+            bgView.isUserInteractionEnabled = false
+            insertSubview(bgView, at: 0)
+            bgView.snp.makeConstraints { $0.edges.equalToSuperview() }
+
+        case .gradient(let gradientId):
+            if let gradient = DesignToken.Gradient(rawValue: gradientId) {
+                applyGradient(gradient)
+            }
+
+        case .customGradient(let startHex, let endHex):
+            let bgView = GradientBackgroundView()
+            bgView.configure(colors: [UIColor(hex: startHex).cgColor, UIColor(hex: endHex).cgColor])
+            bgView.isUserInteractionEnabled = false
+            insertSubview(bgView, at: 0)
+            bgView.snp.makeConstraints { $0.edges.equalToSuperview() }
+
+        case .photo(let fileName):
+            if let data = photoData ?? BackgroundThemeService.shared.loadBackgroundPhoto(fileName: fileName),
+               let image = UIImage(data: data) {
+                let bgView = PhotoBackgroundView()
+                bgView.configure(image: image)
+                bgView.isUserInteractionEnabled = false
+                insertSubview(bgView, at: 0)
+                bgView.snp.makeConstraints { $0.edges.equalToSuperview() }
+            }
+        }
+
+        if config.isDotPatternEnabled {
+            applyDotPattern(dotSize: 5, spacing: 32, color: .token(.textOnAccent))
+        }
+    }
+
+    func bindBackgroundTheme(disposedBy disposeBag: DisposeBag) {
+        BackgroundThemeService.shared.currentConfig
+            .distinctUntilChanged()
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] config in
+                self?.applyBackgroundConfig(config)
+            })
+            .disposed(by: disposeBag)
+    }
+
+    func removeAllBackgroundViews() {
+        subviews.forEach { view in
+            if view is GradientBackgroundView
+                || view is DotPatternBackgroundView
+                || view is SolidColorBackgroundView
+                || view is PhotoBackgroundView {
+                view.removeFromSuperview()
+            }
+        }
     }
 }

--- a/Sahara/Common/Service/BackgroundThemeService.swift
+++ b/Sahara/Common/Service/BackgroundThemeService.swift
@@ -1,0 +1,97 @@
+//
+//  BackgroundThemeService.swift
+//  Sahara
+//
+
+import Foundation
+import RxCocoa
+import RxSwift
+import UIKit
+
+protocol BackgroundThemeServiceProtocol {
+    var currentConfig: BehaviorRelay<BackgroundConfig> { get }
+    func updateTheme(_ theme: BackgroundTheme)
+    func updateDotPattern(enabled: Bool)
+    func saveBackgroundPhoto(_ imageData: Data) throws -> String
+    func loadBackgroundPhoto(fileName: String) -> Data?
+    func deleteBackgroundPhoto(fileName: String)
+}
+
+final class BackgroundThemeService: BackgroundThemeServiceProtocol {
+    static let shared = BackgroundThemeService()
+
+    let currentConfig: BehaviorRelay<BackgroundConfig>
+
+    private let userDefaults: UserDefaults
+    private let baseDirectory: URL
+    private let fileManager = FileManager.default
+
+    private enum Keys {
+        static let backgroundConfig = "background_config"
+    }
+
+    init(userDefaults: UserDefaults = .standard, baseDirectory: URL? = nil) {
+        self.userDefaults = userDefaults
+
+        if let baseDirectory {
+            self.baseDirectory = baseDirectory
+        } else {
+            let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            self.baseDirectory = appSupport.appendingPathComponent("BackgroundImages", isDirectory: true)
+        }
+
+        try? fileManager.createDirectory(at: self.baseDirectory, withIntermediateDirectories: true)
+
+        let config = Self.loadConfig(from: userDefaults)
+        self.currentConfig = BehaviorRelay(value: config)
+    }
+
+    func updateTheme(_ theme: BackgroundTheme) {
+        let oldConfig = currentConfig.value
+        if case .photo(let oldFileName) = oldConfig.theme, theme != oldConfig.theme {
+            deleteBackgroundPhoto(fileName: oldFileName)
+        }
+
+        var config = oldConfig
+        config.theme = theme
+        saveAndEmit(config)
+    }
+
+    func updateDotPattern(enabled: Bool) {
+        var config = currentConfig.value
+        config.isDotPatternEnabled = enabled
+        saveAndEmit(config)
+    }
+
+    func saveBackgroundPhoto(_ imageData: Data) throws -> String {
+        let fileName = "background_\(UUID().uuidString.prefix(8)).jpg"
+        let fileURL = baseDirectory.appendingPathComponent(fileName)
+        try imageData.write(to: fileURL, options: .atomic)
+        return fileName
+    }
+
+    func loadBackgroundPhoto(fileName: String) -> Data? {
+        let fileURL = baseDirectory.appendingPathComponent(fileName)
+        return try? Data(contentsOf: fileURL)
+    }
+
+    func deleteBackgroundPhoto(fileName: String) {
+        let fileURL = baseDirectory.appendingPathComponent(fileName)
+        try? fileManager.removeItem(at: fileURL)
+    }
+
+    private func saveAndEmit(_ config: BackgroundConfig) {
+        if let data = try? JSONEncoder().encode(config) {
+            userDefaults.set(data, forKey: Keys.backgroundConfig)
+        }
+        currentConfig.accept(config)
+    }
+
+    private static func loadConfig(from userDefaults: UserDefaults) -> BackgroundConfig {
+        guard let data = userDefaults.data(forKey: Keys.backgroundConfig),
+              let config = try? JSONDecoder().decode(BackgroundConfig.self, from: data) else {
+            return .default
+        }
+        return config
+    }
+}

--- a/Sahara/Feature/CardDetail/CardDetailViewController.swift
+++ b/Sahara/Feature/CardDetail/CardDetailViewController.swift
@@ -128,7 +128,7 @@ final class CardDetailViewController: UIViewController {
     }
 
     private func configureUI() {
-        view.applyGradientWithDots(.primary, dotSize: 5, spacing: 32, dotColor: .token(.textOnAccent))
+        view.bindBackgroundTheme(disposedBy: disposeBag)
 
         view.addSubview(customNavigationBar)
         view.addSubview(scrollView)

--- a/Sahara/Feature/CardInfo/CardInfoViewController.swift
+++ b/Sahara/Feature/CardInfo/CardInfoViewController.swift
@@ -118,7 +118,7 @@ final class CardInfoViewController: UIViewController {
     }
 
     private func configureUI() {
-        view.applyGradient(.warm)
+        view.applyBackgroundConfig(BackgroundThemeService.shared.currentConfig.value)
 
         view.addSubview(customNavigationBar)
         view.addSubview(contentView)

--- a/Sahara/Feature/Gallery/CardList/CardListViewController.swift
+++ b/Sahara/Feature/Gallery/CardList/CardListViewController.swift
@@ -128,7 +128,7 @@ final class CardListViewController: UIViewController {
     }
 
     private func configureUI() {
-        view.applyGradientWithDots(.primary, dotSize: 5, spacing: 32, dotColor: .token(.textOnAccent))
+        view.bindBackgroundTheme(disposedBy: disposeBag)
 
         view.addSubview(customNavigationBar)
         view.addSubview(collectionView)

--- a/Sahara/Feature/Gallery/GalleryViewController.swift
+++ b/Sahara/Feature/Gallery/GalleryViewController.swift
@@ -205,7 +205,7 @@ final class GalleryViewController: UIViewController {
     }
     
     private func configureUI() {
-        view.applyGradientWithDots(.primary, dotSize: 5, spacing: 32, dotColor: .token(.textOnAccent))
+        view.bindBackgroundTheme(disposedBy: disposeBag)
 
         view.addSubview(customNavigationBar)
         view.addSubview(emptyStateView)

--- a/Sahara/Feature/MediaEditor/MediaEditorViewController+UI.swift
+++ b/Sahara/Feature/MediaEditor/MediaEditorViewController+UI.swift
@@ -81,7 +81,7 @@ extension MediaEditorViewController {
     }
 
     func configureUI() {
-        view.applyGradient(.warm)
+        view.applyBackgroundConfig(BackgroundThemeService.shared.currentConfig.value)
 
         view.addSubview(cropDimOverlay)
         view.addSubview(customNavigationBar)

--- a/Sahara/Feature/Search/SearchViewController.swift
+++ b/Sahara/Feature/Search/SearchViewController.swift
@@ -93,7 +93,7 @@ final class SearchViewController: UIViewController {
     }
 
     private func configureUI() {
-        view.applyGradientWithDots(.primary, dotSize: 5, spacing: 32, dotColor: .token(.textOnAccent))
+        view.bindBackgroundTheme(disposedBy: disposeBag)
 
         view.addSubview(customNavigationBar)
         view.addSubview(searchBar)

--- a/Sahara/Feature/Settings/BackgroundTheme/BackgroundThemeViewController.swift
+++ b/Sahara/Feature/Settings/BackgroundTheme/BackgroundThemeViewController.swift
@@ -1,0 +1,602 @@
+//
+//  BackgroundThemeViewController.swift
+//  Sahara
+//
+
+import PhotosUI
+import RxCocoa
+import RxSwift
+import SnapKit
+import UIKit
+
+final class BackgroundThemeViewController: UIViewController {
+    private let viewModel: BackgroundThemeViewModel
+    private let disposeBag = DisposeBag()
+
+    private let solidColorRelay = PublishRelay<String>()
+    private let gradientRelay = PublishRelay<String>()
+    private let customGradientRelay = PublishRelay<(String, String)>()
+    private let photoRelay = PublishRelay<Data>()
+    private let dotPatternRelay = BehaviorRelay<Bool>(value: true)
+    private let applyRelay = PublishRelay<Void>()
+
+
+    private let customNavigationBar = CustomNavigationBar()
+
+    private let scrollView: UIScrollView = {
+        let sv = UIScrollView()
+        sv.showsVerticalScrollIndicator = false
+        return sv
+    }()
+
+    private let contentView = UIView()
+
+    private let previewContainer: UIView = {
+        let v = UIView()
+        v.layer.cornerRadius = 20
+        v.clipsToBounds = true
+        return v
+    }()
+
+    private let previewLabel: UILabel = {
+        let label = UILabel()
+        label.text = NSLocalizedString("background.preview", comment: "")
+        label.font = DesignToken.Typography.caption.font
+        label.textColor = .token(.textSecondary)
+        label.textAlignment = .center
+        return label
+    }()
+
+    private let segmentedControl: UISegmentedControl = {
+        let sc = UISegmentedControl(items: [
+            NSLocalizedString("background.solid_color", comment: ""),
+            NSLocalizedString("background.gradient", comment: ""),
+            NSLocalizedString("background.photo", comment: "")
+        ])
+        sc.selectedSegmentIndex = 0
+        sc.setTitleTextAttributes([.font: DesignToken.Typography.caption.font], for: .normal)
+        sc.setTitleTextAttributes([.font: DesignToken.Typography.caption.font], for: .selected)
+        return sc
+    }()
+
+    private let colorGridView = UIView()
+    private let gradientGridView = UIView()
+    private let photoSelectionView = UIView()
+    private let dotPatternContainerView = UIView()
+    private var dotPatternTopConstraints: [Constraint] = []
+
+    private let dotPatternSwitch: UISwitch = {
+        let s = UISwitch()
+        s.onTintColor = .token(.accent)
+        return s
+    }()
+
+    private let dotPatternLabel: UILabel = {
+        let label = UILabel()
+        label.text = NSLocalizedString("background.dot_pattern", comment: "")
+        label.font = DesignToken.Typography.body.font
+        label.textColor = .token(.textPrimary)
+        return label
+    }()
+
+    private let applyButton: UIButton = {
+        let button = UIButton()
+        var config = UIButton.Configuration.filled()
+        config.baseBackgroundColor = .clear
+        config.baseForegroundColor = .token(.textPrimary)
+        config.cornerStyle = .capsule
+        config.contentInsets = NSDirectionalEdgeInsets(top: 12, leading: 24, bottom: 12, trailing: 24)
+
+        var titleAttr = AttributeContainer()
+        titleAttr.font = FontSystem.galmuriMono(size: 14)
+        config.attributedTitle = AttributedString(
+            NSLocalizedString("background.apply", comment: ""),
+            attributes: titleAttr
+        )
+
+        button.configuration = config
+        button.clipsToBounds = true
+        return button
+    }()
+
+    private var colorCells: [UIView] = []
+    private var gradientCells: [UIView] = []
+
+    init(viewModel: BackgroundThemeViewModel = BackgroundThemeViewModel()) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        navigationController?.setNavigationBarHidden(true, animated: false)
+        setupCustomNavigationBar()
+        configureUI()
+        bind()
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        applyButton.applyGradient(.fresh, removeExisting: true)
+    }
+
+    private func setupCustomNavigationBar() {
+        customNavigationBar.configure(title: NSLocalizedString("background.title", comment: ""))
+        customNavigationBar.onLeftButtonTapped = { [weak self] in
+            self?.navigationController?.popViewController(animated: true)
+        }
+    }
+
+    private func configureUI() {
+        view.applyBackgroundConfig(BackgroundThemeService.shared.currentConfig.value)
+
+        view.addSubview(customNavigationBar)
+        view.addSubview(scrollView)
+        scrollView.addSubview(contentView)
+
+        customNavigationBar.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide)
+            make.horizontalEdges.equalToSuperview()
+            make.height.equalTo(54)
+        }
+
+        scrollView.snp.makeConstraints { make in
+            make.top.equalTo(customNavigationBar.snp.bottom)
+            make.horizontalEdges.bottom.equalToSuperview()
+        }
+
+        contentView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+            make.width.equalTo(scrollView)
+        }
+
+        setupPreview()
+        setupSegmentedControl()
+        setupSelectionViews()
+        setupDotPatternToggle()
+        setupApplyButton()
+    }
+
+    private func setupPreview() {
+        contentView.addSubview(previewContainer)
+        previewContainer.addSubview(previewLabel)
+
+        previewContainer.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(20)
+            make.horizontalEdges.equalToSuperview().inset(20)
+            make.height.equalTo(180)
+        }
+
+        previewLabel.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+        }
+    }
+
+    private func setupSegmentedControl() {
+        contentView.addSubview(segmentedControl)
+        segmentedControl.snp.makeConstraints { make in
+            make.top.equalTo(previewContainer.snp.bottom).offset(20)
+            make.horizontalEdges.equalToSuperview().inset(20)
+            make.height.equalTo(36)
+        }
+    }
+
+    private func setupSelectionViews() {
+        contentView.addSubview(colorGridView)
+        contentView.addSubview(gradientGridView)
+        contentView.addSubview(photoSelectionView)
+
+        let selectionTop = segmentedControl.snp.bottom
+
+        colorGridView.snp.makeConstraints { make in
+            make.top.equalTo(selectionTop).offset(20)
+            make.horizontalEdges.equalToSuperview().inset(20)
+        }
+
+        gradientGridView.snp.makeConstraints { make in
+            make.top.equalTo(selectionTop).offset(20)
+            make.horizontalEdges.equalToSuperview().inset(20)
+        }
+
+        photoSelectionView.snp.makeConstraints { make in
+            make.top.equalTo(selectionTop).offset(20)
+            make.horizontalEdges.equalToSuperview().inset(20)
+        }
+
+        gradientGridView.isHidden = true
+        photoSelectionView.isHidden = true
+
+        setupPhotoButton()
+    }
+
+    private func setupPhotoButton() {
+        let addButton = UIButton(type: .system)
+        addButton.setImage(UIImage(systemName: "photo.badge.plus"), for: .normal)
+        addButton.tintColor = .token(.textSecondary)
+        addButton.setTitle("  " + NSLocalizedString("background.select_photo", comment: ""), for: .normal)
+        addButton.titleLabel?.font = DesignToken.Typography.body.font
+        addButton.setTitleColor(.token(.textSecondary), for: .normal)
+        addButton.backgroundColor = .token(.backgroundCard)
+        addButton.layer.cornerRadius = DesignToken.CornerRadius.card
+        addButton.rx.tap
+            .subscribe(onNext: { [weak self] in self?.presentPhotoPicker() })
+            .disposed(by: disposeBag)
+
+        photoSelectionView.addSubview(addButton)
+        addButton.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+            make.height.equalTo(160)
+        }
+    }
+
+    private func setupDotPatternToggle() {
+        contentView.addSubview(dotPatternContainerView)
+
+        dotPatternContainerView.addSubview(dotPatternLabel)
+        dotPatternContainerView.addSubview(dotPatternSwitch)
+
+        dotPatternContainerView.snp.makeConstraints { make in
+            let c0 = make.top.equalTo(colorGridView.snp.bottom).offset(24).constraint
+            let c1 = make.top.equalTo(gradientGridView.snp.bottom).offset(24).constraint
+            let c2 = make.top.equalTo(photoSelectionView.snp.bottom).offset(24).constraint
+            dotPatternTopConstraints = [c0, c1, c2]
+            c1.deactivate()
+            c2.deactivate()
+            make.horizontalEdges.equalToSuperview().inset(20)
+            make.height.equalTo(44)
+        }
+
+        dotPatternLabel.snp.makeConstraints { make in
+            make.leading.centerY.equalToSuperview()
+        }
+
+        dotPatternSwitch.snp.makeConstraints { make in
+            make.trailing.centerY.equalToSuperview()
+        }
+    }
+
+    private func setupApplyButton() {
+        contentView.addSubview(applyButton)
+        applyButton.snp.makeConstraints { make in
+            make.top.equalTo(dotPatternSwitch.snp.bottom).offset(32)
+            make.horizontalEdges.equalToSuperview().inset(40)
+            make.height.equalTo(50)
+            make.bottom.equalToSuperview().offset(-40)
+        }
+    }
+
+    private func bind() {
+        let input = BackgroundThemeViewModel.Input(
+            solidColorSelected: solidColorRelay.asObservable(),
+            gradientSelected: gradientRelay.asObservable(),
+            customGradientSelected: customGradientRelay.asObservable(),
+            photoSelected: photoRelay.asObservable(),
+            dotPatternToggled: dotPatternRelay.asObservable(),
+            applyTapped: applyRelay.asObservable()
+        )
+
+        let output = viewModel.transform(input: input)
+
+        dotPatternSwitch.rx.isOn
+            .bind(to: dotPatternRelay)
+            .disposed(by: disposeBag)
+
+        applyButton.rx.tap
+            .bind(to: applyRelay)
+            .disposed(by: disposeBag)
+
+        segmentedControl.rx.selectedSegmentIndex
+            .subscribe(onNext: { [weak self] index in
+                self?.switchSelectionTab(to: index)
+            })
+            .disposed(by: disposeBag)
+
+        output.presetColors
+            .drive(onNext: { [weak self] colors in
+                self?.buildColorGrid(colors: colors)
+            })
+            .disposed(by: disposeBag)
+
+        output.availableGradients
+            .drive(onNext: { [weak self] gradients in
+                self?.buildGradientGrid(gradients: gradients)
+            })
+            .disposed(by: disposeBag)
+
+        output.currentConfig
+            .drive(onNext: { [weak self] config in
+                self?.updatePreview(config: config)
+                self?.updateSelection(config: config)
+                self?.dotPatternSwitch.isOn = config.isDotPatternEnabled
+            })
+            .disposed(by: disposeBag)
+
+        output.applied
+            .drive(onNext: { [weak self] in
+                self?.navigationController?.popViewController(animated: true)
+            })
+            .disposed(by: disposeBag)
+    }
+
+    private func buildColorGrid(colors: [String]) {
+        colorGridView.subviews.forEach { $0.removeFromSuperview() }
+        colorCells.removeAll()
+
+        let columns = 5
+        let spacing: CGFloat = 12
+        let cellSize: CGFloat = 48
+        let allItems = colors.count + 1
+
+        var lastView: UIView?
+        for index in 0..<allItems {
+            let isPickerButton = index == colors.count
+            let cell = UIView()
+            cell.layer.cornerRadius = cellSize / 2
+            cell.clipsToBounds = true
+
+            if isPickerButton {
+                cell.backgroundColor = .token(.backgroundCard)
+                cell.layer.borderWidth = 1
+                cell.layer.borderColor = UIColor.token(.border).cgColor
+                let icon = UIImageView(image: UIImage(systemName: "plus"))
+                icon.tintColor = .token(.textSecondary)
+                icon.contentMode = .scaleAspectFit
+                cell.addSubview(icon)
+                icon.snp.makeConstraints { $0.center.equalToSuperview(); $0.size.equalTo(20) }
+
+                let tap = UITapGestureRecognizer()
+                tap.rx.event
+                    .subscribe(onNext: { [weak self] _ in self?.presentSolidColorPicker() })
+                    .disposed(by: disposeBag)
+                cell.addGestureRecognizer(tap)
+            } else {
+                let hex = colors[index]
+                cell.backgroundColor = UIColor(hex: hex)
+                cell.tag = index
+
+                if hex == "#FFFFFF" || hex == "#F9FFFF" || hex == "#FFFFC5" {
+                    cell.layer.borderWidth = 1
+                    cell.layer.borderColor = UIColor.token(.border).cgColor
+                }
+
+                let tap = UITapGestureRecognizer()
+                tap.rx.event
+                    .map { _ in hex }
+                    .bind(to: solidColorRelay)
+                    .disposed(by: disposeBag)
+                cell.addGestureRecognizer(tap)
+                colorCells.append(cell)
+            }
+
+            colorGridView.addSubview(cell)
+
+            let row = index / columns
+            let col = index % columns
+
+            cell.snp.makeConstraints { make in
+                make.width.height.equalTo(cellSize)
+                make.leading.equalToSuperview().offset(CGFloat(col) * (cellSize + spacing))
+                make.top.equalToSuperview().offset(CGFloat(row) * (cellSize + spacing))
+            }
+
+            lastView = cell
+        }
+
+        if let lastView {
+            colorGridView.snp.makeConstraints { make in
+                make.bottom.greaterThanOrEqualTo(lastView.snp.bottom)
+            }
+        }
+    }
+
+    private func buildGradientGrid(gradients: [DesignToken.Gradient]) {
+        gradientGridView.subviews.forEach { $0.removeFromSuperview() }
+        gradientCells.removeAll()
+
+        let spacing: CGFloat = 12
+        let cellHeight: CGFloat = 64
+        let totalItems = gradients.count + 1
+
+        var previousView: UIView?
+        for index in 0..<totalItems {
+            let row = index / 2
+            let col = index % 2
+            let isPickerButton = index == gradients.count
+
+            let cell = UIView()
+            cell.layer.cornerRadius = DesignToken.CornerRadius.card
+            cell.clipsToBounds = true
+
+            if isPickerButton {
+                cell.backgroundColor = .token(.backgroundCard)
+                cell.layer.borderWidth = 1
+                cell.layer.borderColor = UIColor.token(.border).cgColor
+                let icon = UIImageView(image: UIImage(systemName: "plus"))
+                icon.tintColor = .token(.textSecondary)
+                icon.contentMode = .scaleAspectFit
+                cell.addSubview(icon)
+                icon.snp.makeConstraints { $0.center.equalToSuperview(); $0.size.equalTo(24) }
+
+                let tap = UITapGestureRecognizer()
+                tap.rx.event
+                    .subscribe(onNext: { [weak self] _ in self?.presentGradientPicker() })
+                    .disposed(by: disposeBag)
+                cell.addGestureRecognizer(tap)
+            } else {
+                let gradient = gradients[index]
+                cell.applyGradient(gradient)
+
+                let tap = UITapGestureRecognizer()
+                tap.rx.event
+                    .map { _ in gradient.rawValue }
+                    .bind(to: gradientRelay)
+                    .disposed(by: disposeBag)
+                cell.addGestureRecognizer(tap)
+                gradientCells.append(cell)
+            }
+
+            gradientGridView.addSubview(cell)
+
+            cell.snp.makeConstraints { make in
+                make.height.equalTo(cellHeight)
+                make.top.equalToSuperview().offset(CGFloat(row) * (cellHeight + spacing))
+
+                if col == 0 {
+                    make.leading.equalToSuperview()
+                    make.trailing.equalTo(gradientGridView.snp.centerX).offset(-spacing / 2)
+                } else {
+                    make.leading.equalTo(gradientGridView.snp.centerX).offset(spacing / 2)
+                    make.trailing.equalToSuperview()
+                }
+            }
+
+            previousView = cell
+        }
+
+        if let previousView {
+            gradientGridView.snp.makeConstraints { make in
+                make.bottom.greaterThanOrEqualTo(previousView.snp.bottom)
+            }
+        }
+    }
+
+    private func updatePreview(config: BackgroundConfig) {
+        previewContainer.removeAllBackgroundViews()
+        previewContainer.subviews.filter { $0 != previewLabel }.forEach { $0.removeFromSuperview() }
+        previewContainer.backgroundColor = .clear
+
+        switch config.theme {
+        case .solidColor(let hex):
+            previewContainer.backgroundColor = UIColor(hex: hex)
+        case .gradient(let gradientId):
+            if let gradient = DesignToken.Gradient(rawValue: gradientId) {
+                previewContainer.applyGradient(gradient)
+            }
+        case .customGradient:
+            previewContainer.applyBackgroundConfig(config)
+        case .photo(let fileName):
+            if let data = BackgroundThemeService.shared.loadBackgroundPhoto(fileName: fileName),
+               let image = UIImage(data: data) {
+                let iv = UIImageView(image: image)
+                iv.contentMode = .scaleAspectFill
+                iv.clipsToBounds = true
+                previewContainer.insertSubview(iv, at: 0)
+                iv.snp.makeConstraints { $0.edges.equalToSuperview() }
+            }
+        }
+
+        if config.isDotPatternEnabled {
+            previewContainer.applyDotPattern(dotSize: 3, spacing: 20, color: .token(.textOnAccent))
+        }
+
+        previewContainer.bringSubviewToFront(previewLabel)
+    }
+
+    private func updateSelection(config: BackgroundConfig) {
+        colorCells.forEach { cell in
+            cell.layer.borderWidth = 0
+            cell.layer.borderColor = nil
+        }
+        gradientCells.forEach { cell in
+            cell.layer.borderWidth = 0
+            cell.layer.borderColor = nil
+        }
+
+        switch config.theme {
+        case .solidColor(let hex):
+            segmentedControl.selectedSegmentIndex = 0
+            if let cell = colorCells.first(where: { $0.backgroundColor == UIColor(hex: hex) }) {
+                cell.layer.borderWidth = 3
+                cell.layer.borderColor = UIColor.white.cgColor
+            }
+        case .gradient(let gradientId):
+            segmentedControl.selectedSegmentIndex = 1
+            let presets = DesignToken.Gradient.backgroundPresets
+            if let index = presets.firstIndex(where: { $0.rawValue == gradientId }),
+               index < gradientCells.count {
+                gradientCells[index].layer.borderWidth = 3
+                gradientCells[index].layer.borderColor = UIColor.white.cgColor
+            }
+        case .customGradient:
+            segmentedControl.selectedSegmentIndex = 1
+        case .photo:
+            segmentedControl.selectedSegmentIndex = 2
+        }
+
+        switchSelectionTab(to: segmentedControl.selectedSegmentIndex)
+    }
+
+    private func switchSelectionTab(to index: Int) {
+        colorGridView.isHidden = index != 0
+        gradientGridView.isHidden = index != 1
+        photoSelectionView.isHidden = index != 2
+        dotPatternTopConstraints.forEach { $0.deactivate() }
+        dotPatternTopConstraints[index].activate()
+        view.layoutIfNeeded()
+    }
+
+    private func presentSolidColorPicker() {
+        let picker = UIColorPickerViewController()
+        picker.supportsAlpha = false
+        picker.delegate = self
+        present(picker, animated: true)
+    }
+
+    private func presentGradientPicker() {
+        let vc = GradientPickerViewController { [weak self] startHex, endHex in
+            self?.customGradientRelay.accept((startHex, endHex))
+        }
+        if let sheet = vc.sheetPresentationController {
+            sheet.detents = [.medium()]
+            sheet.prefersGrabberVisible = true
+        }
+        present(vc, animated: true)
+    }
+
+    private func presentPhotoPicker() {
+        var config = PHPickerConfiguration()
+        config.selectionLimit = 1
+        config.filter = .images
+
+        let picker = PHPickerViewController(configuration: config)
+        picker.delegate = self
+        present(picker, animated: true)
+    }
+}
+
+extension BackgroundThemeViewController: UIColorPickerViewControllerDelegate {
+    func colorPickerViewControllerDidFinish(_ viewController: UIColorPickerViewController) {
+        solidColorRelay.accept(viewController.selectedColor.toHex())
+    }
+}
+
+extension BackgroundThemeViewController: PHPickerViewControllerDelegate {
+    func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+        picker.dismiss(animated: true)
+
+        guard let provider = results.first?.itemProvider,
+              provider.canLoadObject(ofClass: UIImage.self) else { return }
+
+        provider.loadObject(ofClass: UIImage.self) { [weak self] object, _ in
+            guard let image = object as? UIImage else { return }
+
+            let maxDimension: CGFloat = 1920
+            let scale = min(maxDimension / image.size.width, maxDimension / image.size.height, 1.0)
+            let newSize = CGSize(width: image.size.width * scale, height: image.size.height * scale)
+
+            let renderer = UIGraphicsImageRenderer(size: newSize)
+            let resized = renderer.image { _ in
+                image.draw(in: CGRect(origin: .zero, size: newSize))
+            }
+
+            guard let data = resized.jpegData(compressionQuality: 0.85) else { return }
+
+            DispatchQueue.main.async {
+                self?.photoRelay.accept(data)
+            }
+        }
+    }
+}
+

--- a/Sahara/Feature/Settings/BackgroundTheme/BackgroundThemeViewModel.swift
+++ b/Sahara/Feature/Settings/BackgroundTheme/BackgroundThemeViewModel.swift
@@ -1,0 +1,114 @@
+//
+//  BackgroundThemeViewModel.swift
+//  Sahara
+//
+
+import Foundation
+import PhotosUI
+import RxCocoa
+import RxSwift
+
+final class BackgroundThemeViewModel: BaseViewModelProtocol {
+    private let service: BackgroundThemeServiceProtocol
+    private let disposeBag = DisposeBag()
+
+    init(service: BackgroundThemeServiceProtocol = BackgroundThemeService.shared) {
+        self.service = service
+    }
+
+    struct Input {
+        let solidColorSelected: Observable<String>
+        let gradientSelected: Observable<String>
+        let customGradientSelected: Observable<(String, String)>
+        let photoSelected: Observable<Data>
+        let dotPatternToggled: Observable<Bool>
+        let applyTapped: Observable<Void>
+    }
+
+    struct Output {
+        let currentConfig: Driver<BackgroundConfig>
+        let presetColors: Driver<[String]>
+        let availableGradients: Driver<[DesignToken.Gradient]>
+        let applied: Driver<Void>
+    }
+
+    func transform(input: Input) -> Output {
+        let pendingConfig = BehaviorRelay<BackgroundConfig>(value: service.currentConfig.value)
+
+        input.solidColorSelected
+            .subscribe(onNext: { hex in
+                var config = pendingConfig.value
+                config.theme = .solidColor(hex: hex)
+                pendingConfig.accept(config)
+            })
+            .disposed(by: disposeBag)
+
+        input.gradientSelected
+            .subscribe(onNext: { gradientId in
+                var config = pendingConfig.value
+                config.theme = .gradient(gradientId: gradientId)
+                pendingConfig.accept(config)
+            })
+            .disposed(by: disposeBag)
+
+        input.customGradientSelected
+            .subscribe(onNext: { startHex, endHex in
+                var config = pendingConfig.value
+                config.theme = .customGradient(startHex: startHex, endHex: endHex)
+                pendingConfig.accept(config)
+            })
+            .disposed(by: disposeBag)
+
+        input.photoSelected
+            .subscribe(onNext: { [weak self] data in
+                guard let self,
+                      let fileName = try? self.service.saveBackgroundPhoto(data) else { return }
+                if case .photo(let oldFileName) = pendingConfig.value.theme {
+                    let isAppliedPhoto: Bool
+                    if case .photo(let appliedFileName) = self.service.currentConfig.value.theme {
+                        isAppliedPhoto = oldFileName == appliedFileName
+                    } else {
+                        isAppliedPhoto = false
+                    }
+                    if !isAppliedPhoto {
+                        self.service.deleteBackgroundPhoto(fileName: oldFileName)
+                    }
+                }
+                var config = pendingConfig.value
+                config.theme = .photo(fileName: fileName)
+                pendingConfig.accept(config)
+            })
+            .disposed(by: disposeBag)
+
+        input.dotPatternToggled
+            .distinctUntilChanged()
+            .subscribe(onNext: { enabled in
+                var config = pendingConfig.value
+                config.isDotPatternEnabled = enabled
+                pendingConfig.accept(config)
+            })
+            .disposed(by: disposeBag)
+
+        let applied = input.applyTapped
+            .withLatestFrom(pendingConfig)
+            .do(onNext: { [weak self] config in
+                self?.service.updateTheme(config.theme)
+                self?.service.updateDotPattern(enabled: config.isDotPatternEnabled)
+            })
+            .map { _ in }
+            .asDriver(onErrorDriveWith: .empty())
+
+        let presetColors: [String] = [
+            "#FFBDFF", "#F3F2FF", "#D2D1EC", "#6CA9FF", "#F9FFFF",
+            "#4F7BFE", "#A6FDAB", "#FFFFC5", "#FF6B6B", "#FF009F",
+            "#A6A3B4", "#FFFFFF"
+        ]
+
+        return Output(
+            currentConfig: pendingConfig.asDriver(),
+            presetColors: .just(presetColors),
+            availableGradients: .just(DesignToken.Gradient.backgroundPresets),
+            applied: applied
+        )
+    }
+}

--- a/Sahara/Feature/Settings/BackgroundTheme/GradientPickerViewController.swift
+++ b/Sahara/Feature/Settings/BackgroundTheme/GradientPickerViewController.swift
@@ -1,0 +1,163 @@
+//
+//  GradientPickerViewController.swift
+//  Sahara
+//
+
+import SnapKit
+import UIKit
+
+final class GradientPickerViewController: UIViewController {
+    private let onComplete: (String, String) -> Void
+    private let gradientLayer = CAGradientLayer()
+
+    private let previewView: UIView = {
+        let v = UIView()
+        v.layer.cornerRadius = 16
+        v.clipsToBounds = true
+        return v
+    }()
+
+    private let startLabel: UILabel = {
+        let label = UILabel()
+        label.text = NSLocalizedString("background.gradient_start", comment: "")
+        label.font = DesignToken.Typography.body.font
+        label.textColor = .token(.textPrimary)
+        return label
+    }()
+
+    private let endLabel: UILabel = {
+        let label = UILabel()
+        label.text = NSLocalizedString("background.gradient_end", comment: "")
+        label.font = DesignToken.Typography.body.font
+        label.textColor = .token(.textPrimary)
+        return label
+    }()
+
+    private let startColorWell: UIColorWell = {
+        let well = UIColorWell()
+        well.selectedColor = UIColor(hex: "#FFBDFF")
+        well.supportsAlpha = false
+        return well
+    }()
+
+    private let endColorWell: UIColorWell = {
+        let well = UIColorWell()
+        well.selectedColor = UIColor(hex: "#6CA9FF")
+        well.supportsAlpha = false
+        return well
+    }()
+
+    private let doneButton: UIButton = {
+        let button = UIButton()
+        var config = UIButton.Configuration.filled()
+        config.baseBackgroundColor = .clear
+        config.baseForegroundColor = .token(.textPrimary)
+        config.cornerStyle = .capsule
+        config.contentInsets = NSDirectionalEdgeInsets(top: 12, leading: 24, bottom: 12, trailing: 24)
+
+        var titleAttr = AttributeContainer()
+        titleAttr.font = FontSystem.galmuriMono(size: 14)
+        config.attributedTitle = AttributedString(
+            NSLocalizedString("background.apply", comment: ""),
+            attributes: titleAttr
+        )
+
+        button.configuration = config
+        button.clipsToBounds = true
+        return button
+    }()
+
+    init(onComplete: @escaping (String, String) -> Void) {
+        self.onComplete = onComplete
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = UIColor.token(.backgroundPrimary)
+        configureUI()
+        setupGradientLayer()
+
+        startColorWell.addTarget(self, action: #selector(colorChanged), for: .valueChanged)
+        endColorWell.addTarget(self, action: #selector(colorChanged), for: .valueChanged)
+        doneButton.addTarget(self, action: #selector(doneTapped), for: .touchUpInside)
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        gradientLayer.frame = previewView.bounds
+        doneButton.applyGradient(.fresh, removeExisting: true)
+    }
+
+    private func configureUI() {
+        view.addSubview(previewView)
+        view.addSubview(startLabel)
+        view.addSubview(startColorWell)
+        view.addSubview(endLabel)
+        view.addSubview(endColorWell)
+        view.addSubview(doneButton)
+
+        previewView.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).offset(24)
+            make.horizontalEdges.equalToSuperview().inset(20)
+            make.height.equalTo(120)
+        }
+
+        startLabel.snp.makeConstraints { make in
+            make.top.equalTo(previewView.snp.bottom).offset(24)
+            make.leading.equalToSuperview().inset(20)
+        }
+
+        startColorWell.snp.makeConstraints { make in
+            make.centerY.equalTo(startLabel)
+            make.trailing.equalToSuperview().inset(20)
+            make.size.equalTo(44)
+        }
+
+        endLabel.snp.makeConstraints { make in
+            make.top.equalTo(startLabel.snp.bottom).offset(20)
+            make.leading.equalToSuperview().inset(20)
+        }
+
+        endColorWell.snp.makeConstraints { make in
+            make.centerY.equalTo(endLabel)
+            make.trailing.equalToSuperview().inset(20)
+            make.size.equalTo(44)
+        }
+
+        doneButton.snp.makeConstraints { make in
+            make.top.equalTo(endLabel.snp.bottom).offset(32)
+            make.horizontalEdges.equalToSuperview().inset(40)
+            make.height.equalTo(50)
+        }
+    }
+
+    private func setupGradientLayer() {
+        gradientLayer.locations = [0.0, 1.0]
+        gradientLayer.startPoint = CGPoint(x: 0.5, y: 0)
+        gradientLayer.endPoint = CGPoint(x: 0.5, y: 1)
+        previewView.layer.insertSublayer(gradientLayer, at: 0)
+        updatePreviewColors()
+    }
+
+    private func updatePreviewColors() {
+        gradientLayer.colors = [
+            startColorWell.selectedColor!.cgColor,
+            endColorWell.selectedColor!.cgColor
+        ]
+    }
+
+    @objc private func colorChanged() {
+        updatePreviewColors()
+    }
+
+    @objc private func doneTapped() {
+        let startHex = startColorWell.selectedColor?.toHex() ?? "#FFBDFF"
+        let endHex = endColorWell.selectedColor?.toHex() ?? "#6CA9FF"
+        dismiss(animated: true) { [weak self] in
+            self?.onComplete(startHex, endHex)
+        }
+    }
+}

--- a/Sahara/Feature/Settings/LanguageSelectionViewController.swift
+++ b/Sahara/Feature/Settings/LanguageSelectionViewController.swift
@@ -56,7 +56,7 @@ final class LanguageSelectionViewController: UIViewController {
     }
 
     private func configureUI() {
-        view.applyGradientWithDots(.primary, dotSize: 5, spacing: 32, dotColor: .token(.textOnAccent))
+        view.bindBackgroundTheme(disposedBy: disposeBag)
 
         view.addSubview(customNavigationBar)
         view.addSubview(tableView)

--- a/Sahara/Feature/Settings/Model/BackgroundConfig.swift
+++ b/Sahara/Feature/Settings/Model/BackgroundConfig.swift
@@ -1,0 +1,23 @@
+//
+//  BackgroundConfig.swift
+//  Sahara
+//
+
+import Foundation
+
+enum BackgroundTheme: Codable, Equatable {
+    case solidColor(hex: String)
+    case gradient(gradientId: String)
+    case customGradient(startHex: String, endHex: String)
+    case photo(fileName: String)
+}
+
+struct BackgroundConfig: Codable, Equatable {
+    var theme: BackgroundTheme
+    var isDotPatternEnabled: Bool
+
+    static let `default` = BackgroundConfig(
+        theme: .gradient(gradientId: "primary"),
+        isDotPatternEnabled: true
+    )
+}

--- a/Sahara/Feature/Settings/ReleaseNotesViewController.swift
+++ b/Sahara/Feature/Settings/ReleaseNotesViewController.swift
@@ -66,7 +66,7 @@ final class ReleaseNotesViewController: UIViewController {
     }
 
     private func configureUI() {
-        view.applyGradientWithDots(.primary, dotSize: 5, spacing: 32, dotColor: .token(.textOnAccent))
+        view.bindBackgroundTheme(disposedBy: disposeBag)
 
         view.addSubview(customNavigationBar)
         view.addSubview(tableView)

--- a/Sahara/Feature/Settings/SettingsMenuItem.swift
+++ b/Sahara/Feature/Settings/SettingsMenuItem.swift
@@ -9,6 +9,7 @@ import Foundation
 
 enum SettingsMenuItem: CaseIterable {
     case language
+    case backgroundTheme
     case cloudSync
     case exportPhotos
     case exportBackup
@@ -22,6 +23,8 @@ enum SettingsMenuItem: CaseIterable {
         switch self {
         case .language:
             return NSLocalizedString("settings.language", comment: "")
+        case .backgroundTheme:
+            return NSLocalizedString("settings.background_theme", comment: "")
         case .cloudSync:
             return NSLocalizedString("settings.cloud_sync", comment: "")
         case .exportPhotos:
@@ -45,6 +48,8 @@ enum SettingsMenuItem: CaseIterable {
         switch self {
         case .language:
             return LanguageService.shared.currentLanguageDescription
+        case .backgroundTheme:
+            return nil
         case .cloudSync:
             return NSLocalizedString("settings.cloud_sync_desc", comment: "")
         case .serviceNews:
@@ -58,7 +63,7 @@ enum SettingsMenuItem: CaseIterable {
 
     var isSelectable: Bool {
         switch self {
-        case .language, .contactDeveloper, .releaseNotes, .exportPhotos, .exportBackup, .importBackup:
+        case .language, .backgroundTheme, .contactDeveloper, .releaseNotes, .exportPhotos, .exportBackup, .importBackup:
             return true
         case .cloudSync, .serviceNews, .versionInfo:
             return false

--- a/Sahara/Feature/Settings/SettingsViewController.swift
+++ b/Sahara/Feature/Settings/SettingsViewController.swift
@@ -79,7 +79,7 @@ final class SettingsViewController: UIViewController {
     }
 
     private func configureUI() {
-        view.applyGradientWithDots(.primary, dotSize: 5, spacing: 32, dotColor: .token(.textOnAccent))
+        view.bindBackgroundTheme(disposedBy: disposeBag)
 
         view.addSubview(customNavigationBar)
         view.addSubview(collectionView)
@@ -159,6 +159,13 @@ final class SettingsViewController: UIViewController {
             .drive(with: self) { owner, _ in
                 let languageVC = LanguageSelectionViewController()
                 owner.navigationController?.pushViewController(languageVC, animated: true)
+            }
+            .disposed(by: disposeBag)
+
+        output.openBackgroundTheme
+            .drive(with: self) { owner, _ in
+                let bgVC = BackgroundThemeViewController()
+                owner.navigationController?.pushViewController(bgVC, animated: true)
             }
             .disposed(by: disposeBag)
 

--- a/Sahara/Feature/Settings/SettingsViewModel.swift
+++ b/Sahara/Feature/Settings/SettingsViewModel.swift
@@ -20,6 +20,7 @@ final class SettingsViewModel: BaseViewModelProtocol {
     struct Output {
         let sections: Driver<[SettingsSection]>
         let openLanguageSelection: Driver<Void>
+        let openBackgroundTheme: Driver<Void>
         let openMailComposer: Driver<String>
         let openReleaseNotes: Driver<Void>
         let exportPhotos: Driver<Void>
@@ -29,7 +30,7 @@ final class SettingsViewModel: BaseViewModelProtocol {
 
     func transform(input: Input) -> Output {
         let defaultSections = [
-            SettingsSection(type: .general, items: [.language]),
+            SettingsSection(type: .general, items: [.language, .backgroundTheme]),
             SettingsSection(type: .dataManagement, items: [.exportPhotos, .exportBackup, .importBackup, .cloudSync]),
             SettingsSection(type: .notifications, items: [.serviceNews]),
             SettingsSection(type: .support, items: [.contactDeveloper]),
@@ -41,6 +42,7 @@ final class SettingsViewModel: BaseViewModelProtocol {
             .asDriver(onErrorJustReturn: defaultSections)
 
         let openLanguageSelection = input.itemSelected.whenSelected(.language)
+        let openBackgroundTheme = input.itemSelected.whenSelected(.backgroundTheme)
         let openMailComposer = input.itemSelected
             .compactMap { $0 == .contactDeveloper ? DeveloperConfig.developerEmail : nil }
             .asDriver(onErrorDriveWith: .empty())
@@ -52,6 +54,7 @@ final class SettingsViewModel: BaseViewModelProtocol {
         return Output(
             sections: sections,
             openLanguageSelection: openLanguageSelection,
+            openBackgroundTheme: openBackgroundTheme,
             openMailComposer: openMailComposer,
             openReleaseNotes: openReleaseNotes,
             exportPhotos: exportPhotos,

--- a/Sahara/Feature/Stats/StatsViewController.swift
+++ b/Sahara/Feature/Stats/StatsViewController.swift
@@ -150,7 +150,7 @@ final class StatsViewController: UIViewController {
     }
 
     private func configureUI() {
-        view.applyGradientWithDots(.primary, dotSize: 5, spacing: 32, dotColor: .token(.textOnAccent))
+        view.bindBackgroundTheme(disposedBy: disposeBag)
 
         timeChartView.setBarGradient(.highlight)
         weekdayChartView.setBarGradient(.highlight)

--- a/Sahara/Resources/en.lproj/Localizable.strings
+++ b/Sahara/Resources/en.lproj/Localizable.strings
@@ -190,6 +190,7 @@
 "settings.section_about" = "About";
 "settings.language" = "Language";
 "settings.language_desc" = "English";
+"settings.background_theme" = "Background Theme";
 "settings.service_news" = "Service News";
 "settings.service_news_desc" = "New features and updates";
 "settings.monthly_report" = "Monthly Report";
@@ -300,3 +301,15 @@
 "release_note.1.1.0.1" = "Card lock feature added";
 "release_note.1.1.0.2" = "Easier location editing";
 "release_note.1.1.0.3" = "Improved app stability";
+
+/* Background Theme */
+"background.title" = "Background Theme";
+"background.solid_color" = "Solid Color";
+"background.gradient" = "Gradient";
+"background.photo" = "Photo";
+"background.dot_pattern" = "Dot Pattern";
+"background.preview" = "Preview";
+"background.select_photo" = "Select from Album";
+"background.apply" = "Apply";
+"background.gradient_start" = "Start Color";
+"background.gradient_end" = "End Color";

--- a/Sahara/Resources/ja.lproj/Localizable.strings
+++ b/Sahara/Resources/ja.lproj/Localizable.strings
@@ -190,6 +190,7 @@
 "settings.section_about" = "情報";
 "settings.language" = "言語";
 "settings.language_desc" = "日本語";
+"settings.background_theme" = "背景テーマ";
 "settings.service_news" = "サービスニュース";
 "settings.service_news_desc" = "新機能とアップデート情報";
 "settings.monthly_report" = "月間レポート";
@@ -300,3 +301,15 @@
 "release_note.1.1.0.1" = "カードロック機能が追加されました";
 "release_note.1.1.0.2" = "位置情報の編集がより簡単になりました";
 "release_note.1.1.0.3" = "アプリの安定性が向上しました";
+
+/* Background Theme */
+"background.title" = "背景テーマ";
+"background.solid_color" = "単色";
+"background.gradient" = "グラデーション";
+"background.photo" = "写真";
+"background.dot_pattern" = "ドットパターン";
+"background.preview" = "プレビュー";
+"background.select_photo" = "アルバムから写真を選択";
+"background.apply" = "適用する";
+"background.gradient_start" = "開始色";
+"background.gradient_end" = "終了色";

--- a/Sahara/Resources/ko.lproj/Localizable.strings
+++ b/Sahara/Resources/ko.lproj/Localizable.strings
@@ -190,6 +190,7 @@
 "settings.section_about" = "정보";
 "settings.language" = "언어";
 "settings.language_desc" = "한국어";
+"settings.background_theme" = "배경 테마";
 "settings.service_news" = "서비스 소식";
 "settings.service_news_desc" = "새로운 기능과 업데이트 소식";
 "settings.monthly_report" = "월간 리포트";
@@ -300,3 +301,15 @@
 "release_note.1.1.0.1" = "카드 잠금 기능이 추가되었어요";
 "release_note.1.1.0.2" = "위치 정보 수정이 더 쉬워졌어요";
 "release_note.1.1.0.3" = "앱이 더 안정적으로 작동해요";
+
+/* Background Theme */
+"background.title" = "배경 테마";
+"background.solid_color" = "단색";
+"background.gradient" = "그라데이션";
+"background.photo" = "사진";
+"background.dot_pattern" = "도트 패턴";
+"background.preview" = "미리보기";
+"background.select_photo" = "앨범에서 사진 선택";
+"background.apply" = "적용하기";
+"background.gradient_start" = "시작 색상";
+"background.gradient_end" = "끝 색상";

--- a/Sahara/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sahara/Resources/zh-Hans.lproj/Localizable.strings
@@ -190,6 +190,7 @@
 "settings.section_about" = "关于";
 "settings.language" = "语言";
 "settings.language_desc" = "简体中文";
+"settings.background_theme" = "背景主题";
 "settings.service_news" = "服务动态";
 "settings.service_news_desc" = "新功能和更新消息";
 "settings.monthly_report" = "每月报告";
@@ -294,3 +295,15 @@
 "release_note.1.1.0.1" = "添加了卡片锁定功能";
 "release_note.1.1.0.2" = "位置编辑更加简便";
 "release_note.1.1.0.3" = "应用更加稳定";
+
+/* Background Theme */
+"background.title" = "背景主题";
+"background.solid_color" = "纯色";
+"background.gradient" = "渐变";
+"background.photo" = "照片";
+"background.dot_pattern" = "点状图案";
+"background.preview" = "预览";
+"background.select_photo" = "从相册选择";
+"background.apply" = "应用";
+"background.gradient_start" = "起始颜色";
+"background.gradient_end" = "结束颜色";


### PR DESCRIPTION
Closes #83

## 변경 내용

**추가**
- 배경 테마 설정 화면 (단색 / 프리셋 그래디언트 / 커스텀 그래디언트 / 사진 배경)
- 도트 패턴 on/off 토글
- 배경 테마 모델 및 서비스 (UserDefaults 저장, 사진 파일 관리)
- 설정 화면에 배경 테마 메뉴 항목 추가
- 앱 전체 화면에 선택된 배경 테마 실시간 반영
- 배경 구독 헬퍼 (중복 코드 제거 및 distinctUntilChanged 적용)
- 4개 언어 로컬라이제이션 (한/영/일/중)

## 결정 근거

- **프리뷰 + Apply 패턴** — 변경 사항을 미리보기로 확인한 뒤 적용 버튼을 눌러야 반영되도록 하여 실수를 방지합니다
- **bindBackgroundTheme 헬퍼** — 8개 화면에서 동일한 5줄 구독 코드가 반복되어 1줄로 축약했습니다
- **distinctUntilChanged** — 동일 테마 값이 재방출될 때 불필요한 배경 재구성을 방지합니다