### PR TITLE
Add custom album selector and permission-based photo gallery UI

### DIFF
--- a/Sahara/Feature/CardInfo/Component/AlbumListCell.swift
+++ b/Sahara/Feature/CardInfo/Component/AlbumListCell.swift
@@ -1,0 +1,117 @@
+//
+//  AlbumListCell.swift
+//  Sahara
+//
+//  Created by 금가경 on 3/27/26.
+//
+
+import Photos
+import SnapKit
+import UIKit
+
+final class AlbumListCell: UITableViewCell {
+    static let identifier = "AlbumListCell"
+
+    private let thumbnailImageView: UIImageView = {
+        let iv = UIImageView()
+        iv.contentMode = .scaleAspectFill
+        iv.clipsToBounds = true
+        iv.layer.cornerRadius = 6
+        iv.backgroundColor = .secondarySystemBackground
+        return iv
+    }()
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = FontSystem.galmuriMono(size: 14)
+        label.textColor = .label
+        return label
+    }()
+
+    private let countLabel: UILabel = {
+        let label = UILabel()
+        label.font = FontSystem.galmuriMono(size: 12)
+        label.textColor = .secondaryLabel
+        return label
+    }()
+
+    private let checkmarkLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 16)
+        label.textColor = .token(.accent)
+        label.text = "✓"
+        label.isHidden = true
+        return label
+    }()
+
+    private var imageRequestID: PHImageRequestID?
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        backgroundColor = .clear
+        selectionStyle = .none
+        setupUI()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        thumbnailImageView.image = nil
+        checkmarkLabel.isHidden = true
+        if let requestID = imageRequestID {
+            PHCachingImageManager.default().cancelImageRequest(requestID)
+            imageRequestID = nil
+        }
+    }
+
+    private func setupUI() {
+        let textStack = UIStackView(arrangedSubviews: [titleLabel, countLabel])
+        textStack.axis = .vertical
+        textStack.spacing = 2
+
+        contentView.addSubview(thumbnailImageView)
+        contentView.addSubview(textStack)
+        contentView.addSubview(checkmarkLabel)
+
+        thumbnailImageView.snp.makeConstraints { make in
+            make.leading.equalToSuperview().inset(16)
+            make.centerY.equalToSuperview()
+            make.width.height.equalTo(48)
+        }
+
+        textStack.snp.makeConstraints { make in
+            make.leading.equalTo(thumbnailImageView.snp.trailing).offset(12)
+            make.centerY.equalTo(thumbnailImageView)
+            make.trailing.equalTo(checkmarkLabel.snp.leading).offset(-8)
+        }
+
+        checkmarkLabel.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.trailing.equalToSuperview().inset(16)
+        }
+    }
+
+    func configure(with album: Album, isSelected: Bool, imageManager: PHCachingImageManager) {
+        titleLabel.text = album.title
+        countLabel.text = String(format: NSLocalizedString("media_selection.photo_count", comment: ""), album.count)
+        checkmarkLabel.isHidden = !isSelected
+
+        guard let asset = album.thumbnailAsset else { return }
+        let targetSize = CGSize(width: 96, height: 96)
+        let options = PHImageRequestOptions()
+        options.deliveryMode = .opportunistic
+        options.isNetworkAccessAllowed = true
+
+        imageRequestID = imageManager.requestImage(
+            for: asset,
+            targetSize: targetSize,
+            contentMode: .aspectFill,
+            options: options
+        ) { [weak self] image, _ in
+            self?.thumbnailImageView.image = image
+        }
+    }
+}

--- a/Sahara/Feature/CardInfo/Component/AlbumListOverlayView.swift
+++ b/Sahara/Feature/CardInfo/Component/AlbumListOverlayView.swift
@@ -1,0 +1,59 @@
+//
+//  AlbumListOverlayView.swift
+//  Sahara
+//
+//  Created by 금가경 on 3/27/26.
+//
+
+import SnapKit
+import UIKit
+
+final class AlbumListOverlayView: UIView {
+    let tableView: UITableView = {
+        let tv = UITableView()
+        tv.backgroundColor = .systemBackground
+        tv.rowHeight = 60
+        tv.separatorStyle = .none
+        tv.register(AlbumListCell.self, forCellReuseIdentifier: AlbumListCell.identifier)
+        tv.showsVerticalScrollIndicator = false
+        return tv
+    }()
+
+    private static let maxHeight: CGFloat = 400
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupUI() {
+        backgroundColor = .systemBackground
+        layer.cornerRadius = 12
+        layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
+        clipsToBounds = true
+
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowOpacity = 0.15
+        layer.shadowOffset = CGSize(width: 0, height: 4)
+        layer.shadowRadius = 8
+        layer.masksToBounds = false
+
+        addSubview(tableView)
+        tableView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+            make.height.lessThanOrEqualTo(AlbumListOverlayView.maxHeight)
+        }
+    }
+
+    func updateHeight(for albumCount: Int) {
+        let contentHeight = CGFloat(albumCount) * 60
+        let height = min(contentHeight, AlbumListOverlayView.maxHeight)
+        tableView.snp.updateConstraints { make in
+            make.height.lessThanOrEqualTo(height)
+        }
+    }
+}

--- a/Sahara/Feature/CardInfo/MediaSelectionViewController.swift
+++ b/Sahara/Feature/CardInfo/MediaSelectionViewController.swift
@@ -35,6 +35,82 @@ final class MediaSelectionViewController: UIViewController {
     private let photoSelectedRelay = PublishRelay<PHAsset>()
     private let filePickerButtonTappedRelay = PublishRelay<Void>()
     private let imagePickerResultRelay = PublishRelay<(ImageSourceData, CLLocation?, Date?, MediaSource)>()
+    private let albumSelectedRelay = PublishRelay<Int>()
+
+    // MARK: - Album Selector Bar
+
+    private let albumSelectorBar: UIView = {
+        let view = UIView()
+        view.backgroundColor = .clear
+        return view
+    }()
+
+    private let albumTitleButton: UIButton = {
+        var config = UIButton.Configuration.plain()
+        config.baseForegroundColor = .label
+        config.image = UIImage(systemName: "chevron.down")
+        config.imagePlacement = .trailing
+        config.imagePadding = 4
+        config.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(pointSize: 10, weight: .medium)
+        config.contentInsets = .zero
+        let button = UIButton(configuration: config)
+        return button
+    }()
+
+    private let albumCountLabel: UILabel = {
+        let label = UILabel()
+        label.font = FontSystem.galmuriMono(size: 12)
+        label.textColor = .token(.textSecondary)
+        return label
+    }()
+
+    // MARK: - Limited Banner
+
+    private let limitedBannerContainer: UIView = {
+        let view = UIView()
+        view.backgroundColor = .token(.info).withAlphaComponent(0.1)
+        view.isHidden = true
+        return view
+    }()
+
+    private let bannerInfoIcon: UIImageView = {
+        let iv = UIImageView(image: UIImage(systemName: "info.circle"))
+        iv.tintColor = .token(.info)
+        iv.contentMode = .scaleAspectFit
+        return iv
+    }()
+
+    private let bannerLabel: UILabel = {
+        let label = UILabel()
+        label.text = NSLocalizedString("media_selection.limited_banner", comment: "")
+        label.font = FontSystem.galmuriMono(size: 11)
+        label.textColor = .token(.textSecondary)
+        label.numberOfLines = 0
+        return label
+    }()
+
+    private let settingsLinkButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle(NSLocalizedString("media_selection.allow_all_photos", comment: ""), for: .normal)
+        button.titleLabel?.font = FontSystem.galmuriMono(size: 11)
+        button.setTitleColor(.token(.accent), for: .normal)
+        button.contentHorizontalAlignment = .center
+        return button
+    }()
+
+    // MARK: - Album Overlay
+
+    private let dimView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor.black.withAlphaComponent(0.3)
+        view.alpha = 0
+        view.isHidden = true
+        return view
+    }()
+
+    private let albumListOverlay = AlbumListOverlayView()
+
+    // MARK: - Collection View
 
     private lazy var collectionView: UICollectionView = {
         let layout = GridLayout(numberOfColumns: 3, cellSpacing: 2, minColumnWidth: 110)
@@ -51,6 +127,8 @@ final class MediaSelectionViewController: UIViewController {
     var onMediaSelected: ((ImageSourceData, CLLocation?, Date?) -> Void)?
     private let imageManager = PHCachingImageManager()
     private var isObserverRegistered = false
+    private var isAlbumListVisible = false
+    private var currentSelectedAlbumIndex = 0
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -77,6 +155,8 @@ final class MediaSelectionViewController: UIViewController {
         isObserverRegistered = true
     }
 
+    // MARK: - Bind
+
     private func bind() {
         let input = MediaSelectionViewModel.Input(
             viewWillAppear: viewWillAppearRelay.asObservable(),
@@ -84,7 +164,8 @@ final class MediaSelectionViewController: UIViewController {
             libraryButtonTapped: libraryButtonTappedRelay.asObservable(),
             filePickerButtonTapped: filePickerButtonTappedRelay.asObservable(),
             photoSelected: photoSelectedRelay.asObservable(),
-            imagePickerResult: imagePickerResultRelay.asObservable()
+            imagePickerResult: imagePickerResultRelay.asObservable(),
+            albumSelected: albumSelectedRelay.asObservable()
         )
 
         let output = viewModel.transform(input: input)
@@ -106,11 +187,14 @@ final class MediaSelectionViewController: UIViewController {
             }
         )
 
-        Observable.combineLatest(output.showActionButtons.asObservable(), output.photos.asObservable())
-            .map { showButtons, photos -> [SectionModel<String, MediaCollectionItem>] in
+        Observable.combineLatest(
+            output.showActionButtons.asObservable(),
+            output.photos.asObservable(),
+            output.permissionStatus.asObservable()
+        )
+            .map { showButtons, photos, status -> [SectionModel<String, MediaCollectionItem>] in
                 var sections: [SectionModel<String, MediaCollectionItem>] = []
 
-                let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
                 var actionItems: [MediaCollectionItem] = []
 
                 actionItems.append(.action(
@@ -118,21 +202,20 @@ final class MediaSelectionViewController: UIViewController {
                     title: NSLocalizedString("media_selection.camera", comment: ""),
                     type: .camera
                 ))
-                if status != .authorized {
+
+                if status == .limited {
                     actionItems.append(.action(
                         icon: "photo.on.rectangle",
-                        title: NSLocalizedString("media_selection.library", comment: ""),
+                        title: NSLocalizedString("media_selection.add_photos", comment: ""),
                         type: .library
                     ))
                 }
 
-                #if targetEnvironment(macCatalyst)
                 actionItems.append(.action(
                     icon: "folder",
                     title: NSLocalizedString("media_selection.file", comment: ""),
                     type: .filePicker
                 ))
-                #endif
 
                 sections.append(SectionModel(model: "actions", items: actionItems))
 
@@ -162,6 +245,87 @@ final class MediaSelectionViewController: UIViewController {
             }
             .disposed(by: disposeBag)
 
+        // Album title & count
+        output.currentAlbumTitle
+            .drive(with: self) { owner, title in
+                var attributed = AttributedString(title)
+                attributed.font = FontSystem.galmuriMono(size: 14)
+                owner.albumTitleButton.configuration?.attributedTitle = attributed
+            }
+            .disposed(by: disposeBag)
+
+        output.currentAlbumCount
+            .drive(with: self) { owner, count in
+                owner.albumCountLabel.text = String(
+                    format: NSLocalizedString("media_selection.photo_count", comment: ""),
+                    count
+                )
+            }
+            .disposed(by: disposeBag)
+
+        // Permission-based limited banner
+        output.permissionStatus
+            .drive(with: self) { owner, status in
+                owner.limitedBannerContainer.isHidden = status != .limited
+            }
+            .disposed(by: disposeBag)
+
+        // Album list overlay — bind albums to tableView
+        output.albums
+            .drive(with: self) { owner, albums in
+                owner.albumListOverlay.updateHeight(for: albums.count)
+            }
+            .disposed(by: disposeBag)
+
+        output.albums
+            .drive(albumListOverlay.tableView.rx.items(
+                cellIdentifier: AlbumListCell.identifier,
+                cellType: AlbumListCell.self
+            )) { [weak self] index, album, cell in
+                guard let self = self else { return }
+                cell.configure(
+                    with: album,
+                    isSelected: index == self.currentSelectedAlbumIndex,
+                    imageManager: self.imageManager
+                )
+            }
+            .disposed(by: disposeBag)
+
+        albumListOverlay.tableView.rx.itemSelected
+            .bind(with: self) { owner, indexPath in
+                owner.currentSelectedAlbumIndex = indexPath.row
+                owner.albumSelectedRelay.accept(indexPath.row)
+                owner.toggleAlbumList()
+            }
+            .disposed(by: disposeBag)
+
+        // Album selector button tap
+        albumTitleButton.rx.tap
+            .bind(with: self) { owner, _ in
+                owner.toggleAlbumList()
+            }
+            .disposed(by: disposeBag)
+
+        // Dim view tap → close
+        let dimTap = UITapGestureRecognizer()
+        dimView.addGestureRecognizer(dimTap)
+        dimTap.rx.event
+            .bind(with: self) { owner, _ in
+                if owner.isAlbumListVisible {
+                    owner.toggleAlbumList()
+                }
+            }
+            .disposed(by: disposeBag)
+
+        // Settings link button
+        settingsLinkButton.rx.tap
+            .bind(with: self) { _, _ in
+                guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+                UIApplication.shared.open(url)
+            }
+            .disposed(by: disposeBag)
+
+        // Standard outputs
         output.showCamera
             .drive(with: self) { owner, _ in
                 owner.presentCamera()
@@ -230,6 +394,36 @@ final class MediaSelectionViewController: UIViewController {
             .disposed(by: disposeBag)
     }
 
+    // MARK: - Album List Toggle
+
+    private func toggleAlbumList() {
+        isAlbumListVisible.toggle()
+
+        if isAlbumListVisible {
+            dimView.isHidden = false
+            albumListOverlay.isHidden = false
+        }
+
+        UIView.animate(withDuration: 0.25, animations: { [weak self] in
+            guard let self = self else { return }
+            self.dimView.alpha = self.isAlbumListVisible ? 1 : 0
+            self.albumListOverlay.alpha = self.isAlbumListVisible ? 1 : 0
+
+            let rotation: CGAffineTransform = self.isAlbumListVisible
+                ? CGAffineTransform(rotationAngle: .pi)
+                : .identity
+            self.albumTitleButton.imageView?.transform = rotation
+        }, completion: { [weak self] _ in
+            guard let self = self else { return }
+            if !self.isAlbumListVisible {
+                self.dimView.isHidden = true
+                self.albumListOverlay.isHidden = true
+            }
+        })
+    }
+
+    // MARK: - Present Helpers
+
     private func presentCamera() {
         let cameraVC = CameraViewController()
         cameraVC.modalPresentationStyle = .fullScreen
@@ -256,6 +450,8 @@ final class MediaSelectionViewController: UIViewController {
         present(picker, animated: true)
     }
 
+    // MARK: - Configure UI
+
     private func configureUI() {
         view.applyGradient(.subtle)
 
@@ -274,9 +470,73 @@ final class MediaSelectionViewController: UIViewController {
         closeButton.setTitleTextAttributes([.font: FontSystem.galmuriMono(size: 14)], for: .normal)
         navigationItem.leftBarButtonItem = closeButton
 
-        view.addSubview(collectionView)
-        collectionView.snp.makeConstraints { make in
+        // Album selector bar
+        let albumBarStack = UIStackView(arrangedSubviews: [albumTitleButton, albumCountLabel])
+        albumBarStack.axis = .horizontal
+        albumBarStack.spacing = 8
+        albumBarStack.alignment = .center
+
+        albumSelectorBar.addSubview(albumBarStack)
+        albumBarStack.snp.makeConstraints { make in
+            make.leading.equalToSuperview().inset(16)
+            make.centerY.equalToSuperview()
+        }
+
+        // Limited banner — centered layout
+        let bannerTopRow = UIStackView(arrangedSubviews: [bannerInfoIcon, bannerLabel])
+        bannerTopRow.axis = .horizontal
+        bannerTopRow.spacing = 6
+        bannerTopRow.alignment = .center
+
+        bannerInfoIcon.snp.makeConstraints { make in
+            make.width.height.equalTo(16)
+        }
+
+        let bannerStack = UIStackView(arrangedSubviews: [bannerTopRow, settingsLinkButton])
+        bannerStack.axis = .vertical
+        bannerStack.spacing = 0
+        bannerStack.alignment = .center
+
+        limitedBannerContainer.addSubview(bannerStack)
+        bannerStack.snp.makeConstraints { make in
+            make.centerX.centerY.equalToSuperview()
+            make.top.greaterThanOrEqualToSuperview().inset(10)
+            make.bottom.lessThanOrEqualToSuperview().inset(10)
+            make.leading.greaterThanOrEqualToSuperview().inset(16)
+            make.trailing.lessThanOrEqualToSuperview().inset(16)
+        }
+
+        // Main stack: albumSelectorBar + limitedBanner + collectionView
+        let contentStack = UIStackView(arrangedSubviews: [
+            albumSelectorBar, limitedBannerContainer, collectionView
+        ])
+        contentStack.axis = .vertical
+
+        albumSelectorBar.snp.makeConstraints { make in
+            make.height.equalTo(44)
+        }
+
+        limitedBannerContainer.snp.makeConstraints { make in
+            make.height.equalTo(52)
+        }
+
+        view.addSubview(contentStack)
+        contentStack.snp.makeConstraints { make in
+            make.edges.equalTo(view.safeAreaLayoutGuide)
+        }
+
+        // Dim + overlay (above everything)
+        view.addSubview(dimView)
+        dimView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
+        }
+
+        albumListOverlay.alpha = 0
+        albumListOverlay.isHidden = true
+        view.addSubview(albumListOverlay)
+        albumListOverlay.snp.makeConstraints { make in
+            make.top.equalTo(albumSelectorBar.snp.bottom)
+            make.leading.trailing.equalToSuperview()
         }
     }
 
@@ -284,6 +544,8 @@ final class MediaSelectionViewController: UIViewController {
         dismiss(animated: true)
     }
 }
+
+// MARK: - UIDocumentPickerDelegate
 
 extension MediaSelectionViewController: UIDocumentPickerDelegate {
     func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
@@ -312,6 +574,8 @@ extension MediaSelectionViewController: UIDocumentPickerDelegate {
         }
     }
 }
+
+// MARK: - PHPickerViewControllerDelegate
 
 extension MediaSelectionViewController: PHPickerViewControllerDelegate {
     func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
@@ -368,6 +632,8 @@ extension MediaSelectionViewController: PHPickerViewControllerDelegate {
     }
 }
 
+// MARK: - PHPhotoLibraryChangeObserver
+
 extension MediaSelectionViewController: PHPhotoLibraryChangeObserver {
     func photoLibraryDidChange(_ changeInstance: PHChange) {
         DispatchQueue.main.async { [weak self] in
@@ -375,6 +641,8 @@ extension MediaSelectionViewController: PHPhotoLibraryChangeObserver {
         }
     }
 }
+
+// MARK: - ActionCell
 
 final class ActionCell: UICollectionViewCell {
     private let iconImageView: UIImageView = {
@@ -423,4 +691,3 @@ final class ActionCell: UICollectionViewCell {
         titleLabel.text = title
     }
 }
-

--- a/Sahara/Feature/CardInfo/MediaSelectionViewModel.swift
+++ b/Sahara/Feature/CardInfo/MediaSelectionViewModel.swift
@@ -20,6 +20,13 @@ enum MediaSource {
     case filePicker
 }
 
+struct Album {
+    let collection: PHAssetCollection?
+    let title: String
+    let count: Int
+    let thumbnailAsset: PHAsset?
+}
+
 final class MediaSelectionViewModel: BaseViewModelProtocol {
     private let disposeBag = DisposeBag()
 
@@ -30,6 +37,7 @@ final class MediaSelectionViewModel: BaseViewModelProtocol {
         let filePickerButtonTapped: Observable<Void>
         let photoSelected: Observable<PHAsset>
         let imagePickerResult: Observable<(ImageSourceData, CLLocation?, Date?, MediaSource)>
+        let albumSelected: Observable<Int>
     }
 
     struct Output {
@@ -44,6 +52,10 @@ final class MediaSelectionViewModel: BaseViewModelProtocol {
         let requestPhotoPermission: Driver<Void>
         let requestCameraPermission: Driver<Void>
         let showLimitedLibraryPicker: Driver<Void>
+        let albums: Driver<[Album]>
+        let currentAlbumTitle: Driver<String>
+        let currentAlbumCount: Driver<Int>
+        let permissionStatus: Driver<PHAuthorizationStatus>
     }
 
     func transform(input: Input) -> Output {
@@ -57,12 +69,33 @@ final class MediaSelectionViewModel: BaseViewModelProtocol {
         let requestCameraPermissionRelay = PublishRelay<Void>()
         let showLimitedLibraryPickerRelay = PublishRelay<Void>()
         let showFilePickerRelay = PublishRelay<Void>()
+        let albumsRelay = BehaviorRelay<[Album]>(value: [])
+        let selectedAlbumIndexRelay = BehaviorRelay<Int>(value: 0)
+        let permissionStatusRelay = BehaviorRelay<PHAuthorizationStatus>(
+            value: PHPhotoLibrary.authorizationStatus(for: .readWrite)
+        )
 
         input.viewWillAppear
             .bind(with: self) { owner, _ in
+                let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
+                permissionStatusRelay.accept(status)
+
                 owner.handleInitialPhotoLoad(
                     photosRelay: photosRelay,
+                    albumsRelay: albumsRelay,
+                    selectedAlbumIndexRelay: selectedAlbumIndexRelay,
                     requestPhotoPermissionRelay: requestPhotoPermissionRelay
+                )
+            }
+            .disposed(by: disposeBag)
+
+        input.albumSelected
+            .bind(with: self) { owner, index in
+                selectedAlbumIndexRelay.accept(index)
+                owner.fetchPhotosForAlbum(
+                    at: index,
+                    albumsRelay: albumsRelay,
+                    photosRelay: photosRelay
                 )
             }
             .disposed(by: disposeBag)
@@ -130,6 +163,24 @@ final class MediaSelectionViewModel: BaseViewModelProtocol {
         let showActionButtons = Observable.just(true)
             .asDriver(onErrorJustReturn: true)
 
+        let currentAlbumTitle = Observable
+            .combineLatest(albumsRelay, selectedAlbumIndexRelay)
+            .map { albums, index -> String in
+                guard index < albums.count else {
+                    return NSLocalizedString("media_selection.all_photos", comment: "")
+                }
+                return albums[index].title
+            }
+            .asDriver(onErrorJustReturn: NSLocalizedString("media_selection.all_photos", comment: ""))
+
+        let currentAlbumCount = Observable
+            .combineLatest(albumsRelay, selectedAlbumIndexRelay)
+            .map { albums, index -> Int in
+                guard index < albums.count else { return 0 }
+                return albums[index].count
+            }
+            .asDriver(onErrorJustReturn: 0)
+
         return Output(
             photos: photosRelay.asDriver(),
             showActionButtons: showActionButtons,
@@ -141,12 +192,18 @@ final class MediaSelectionViewModel: BaseViewModelProtocol {
             selectedMedia: selectedMediaRelay.asDriver(onErrorDriveWith: .empty()),
             requestPhotoPermission: requestPhotoPermissionRelay.asDriver(onErrorJustReturn: ()),
             requestCameraPermission: requestCameraPermissionRelay.asDriver(onErrorJustReturn: ()),
-            showLimitedLibraryPicker: showLimitedLibraryPickerRelay.asDriver(onErrorJustReturn: ())
+            showLimitedLibraryPicker: showLimitedLibraryPickerRelay.asDriver(onErrorJustReturn: ()),
+            albums: albumsRelay.asDriver(),
+            currentAlbumTitle: currentAlbumTitle,
+            currentAlbumCount: currentAlbumCount,
+            permissionStatus: permissionStatusRelay.asDriver()
         )
     }
 
     private func handleInitialPhotoLoad(
         photosRelay: BehaviorRelay<[PHAsset]>,
+        albumsRelay: BehaviorRelay<[Album]>,
+        selectedAlbumIndexRelay: BehaviorRelay<Int>,
         requestPhotoPermissionRelay: PublishRelay<Void>
     ) {
         #if targetEnvironment(macCatalyst)
@@ -156,7 +213,9 @@ final class MediaSelectionViewModel: BaseViewModelProtocol {
             return
         }
         #endif
-        fetchPhotos(relay: photosRelay)
+        fetchAlbums(albumsRelay: albumsRelay)
+        selectedAlbumIndexRelay.accept(0)
+        fetchPhotosForAlbum(at: 0, albumsRelay: albumsRelay, photosRelay: photosRelay)
     }
 
     private func handleLibraryButtonTapped(
@@ -189,23 +248,113 @@ final class MediaSelectionViewModel: BaseViewModelProtocol {
         #endif
     }
 
-    private func fetchPhotos(relay: BehaviorRelay<[PHAsset]>) {
+    private func fetchAlbums(albumsRelay: BehaviorRelay<[Album]>) {
         let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
         guard status == .authorized || status == .limited else {
-            relay.accept([])
+            albumsRelay.accept([])
+            return
+        }
+
+        let isLimited = status == .limited
+        var albums: [Album] = []
+
+        let allPhotosOptions = PHFetchOptions()
+        allPhotosOptions.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
+        let allPhotosResult = PHAsset.fetchAssets(with: .image, options: allPhotosOptions)
+        let allPhotosTitle = isLimited
+            ? NSLocalizedString("media_selection.allowed_photos", comment: "")
+            : NSLocalizedString("media_selection.all_photos", comment: "")
+
+        albums.append(Album(
+            collection: nil,
+            title: allPhotosTitle,
+            count: allPhotosResult.count,
+            thumbnailAsset: allPhotosResult.firstObject
+        ))
+
+        let smartAlbumSubtypes: [PHAssetCollectionSubtype] = [
+            .smartAlbumRecentlyAdded,
+            .smartAlbumFavorites,
+            .smartAlbumSelfPortraits,
+            .smartAlbumScreenshots,
+            .smartAlbumLivePhotos,
+            .smartAlbumPanoramas
+        ]
+
+        for subtype in smartAlbumSubtypes {
+            let result = PHAssetCollection.fetchAssetCollections(
+                with: .smartAlbum, subtype: subtype, options: nil
+            )
+            result.enumerateObjects { collection, _, _ in
+                let fetchOptions = PHFetchOptions()
+                fetchOptions.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
+                fetchOptions.predicate = NSPredicate(format: "mediaType == %d", PHAssetMediaType.image.rawValue)
+                let assets = PHAsset.fetchAssets(in: collection, options: fetchOptions)
+                guard assets.count > 0 else { return }
+
+                albums.append(Album(
+                    collection: collection,
+                    title: collection.localizedTitle ?? "",
+                    count: assets.count,
+                    thumbnailAsset: assets.firstObject
+                ))
+            }
+        }
+
+        let userAlbums = PHAssetCollection.fetchAssetCollections(
+            with: .album, subtype: .any, options: nil
+        )
+        userAlbums.enumerateObjects { collection, _, _ in
+            let fetchOptions = PHFetchOptions()
+            fetchOptions.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
+            fetchOptions.predicate = NSPredicate(format: "mediaType == %d", PHAssetMediaType.image.rawValue)
+            let assets = PHAsset.fetchAssets(in: collection, options: fetchOptions)
+            guard assets.count > 0 else { return }
+
+            albums.append(Album(
+                collection: collection,
+                title: collection.localizedTitle ?? "",
+                count: assets.count,
+                thumbnailAsset: assets.firstObject
+            ))
+        }
+
+        albumsRelay.accept(albums)
+    }
+
+    private func fetchPhotosForAlbum(
+        at index: Int,
+        albumsRelay: BehaviorRelay<[Album]>,
+        photosRelay: BehaviorRelay<[PHAsset]>
+    ) {
+        let albums = albumsRelay.value
+        guard index < albums.count else {
+            photosRelay.accept([])
+            return
+        }
+
+        let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
+        guard status == .authorized || status == .limited else {
+            photosRelay.accept([])
             return
         }
 
         let fetchOptions = PHFetchOptions()
         fetchOptions.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
 
-        let results = PHAsset.fetchAssets(with: .image, options: fetchOptions)
+        let results: PHFetchResult<PHAsset>
+        if let collection = albums[index].collection {
+            fetchOptions.predicate = NSPredicate(format: "mediaType == %d", PHAssetMediaType.image.rawValue)
+            results = PHAsset.fetchAssets(in: collection, options: fetchOptions)
+        } else {
+            results = PHAsset.fetchAssets(with: .image, options: fetchOptions)
+        }
+
         var photos: [PHAsset] = []
         results.enumerateObjects { asset, _, _ in
             photos.append(asset)
         }
-
-        relay.accept(photos)
+        photosRelay.accept(photos)
     }
 
     private func loadImage(from asset: PHAsset) -> Observable<(ImageSourceData, CLLocation?, Date?)> {

--- a/Sahara/Resources/en.lproj/Localizable.strings
+++ b/Sahara/Resources/en.lproj/Localizable.strings
@@ -91,6 +91,12 @@
 "media_selection.photo_permission_message" = "Please allow photo library access in Settings";
 "media_selection.file" = "File";
 "media_selection.go_to_settings" = "Go to Settings";
+"media_selection.all_photos" = "All Photos";
+"media_selection.allowed_photos" = "Allowed Photos";
+"media_selection.add_photos" = "Add Photos";
+"media_selection.limited_banner" = "You have granted access to selected photos only";
+"media_selection.allow_all_photos" = "Allow access to all photos in Settings";
+"media_selection.photo_count" = "%d";
 
 /* Camera */
 "camera.unavailable_title" = "Camera Unavailable";

--- a/Sahara/Resources/ja.lproj/Localizable.strings
+++ b/Sahara/Resources/ja.lproj/Localizable.strings
@@ -91,6 +91,12 @@
 "media_selection.photo_permission_message" = "設定でフォトライブラリアクセス権限を許可してください";
 "media_selection.file" = "ファイル";
 "media_selection.go_to_settings" = "設定に移動";
+"media_selection.all_photos" = "すべての写真";
+"media_selection.allowed_photos" = "許可された写真";
+"media_selection.add_photos" = "写真を追加";
+"media_selection.limited_banner" = "一部の写真のみアクセスが許可されています";
+"media_selection.allow_all_photos" = "設定ですべての写真を許可する";
+"media_selection.photo_count" = "%d枚";
 
 /* Camera */
 "camera.unavailable_title" = "カメラを使用できません";

--- a/Sahara/Resources/ko.lproj/Localizable.strings
+++ b/Sahara/Resources/ko.lproj/Localizable.strings
@@ -91,6 +91,12 @@
 "media_selection.photo_permission_message" = "사진을 선택하려면 설정에서 사진 라이브러리 권한을 허용해요";
 "media_selection.file" = "파일";
 "media_selection.go_to_settings" = "설정으로 이동";
+"media_selection.all_photos" = "모든 사진";
+"media_selection.allowed_photos" = "허용된 사진";
+"media_selection.add_photos" = "사진 추가";
+"media_selection.limited_banner" = "일부 사진에만 접근이 허용되었습니다";
+"media_selection.allow_all_photos" = "설정에서 모든 사진 허용하기";
+"media_selection.photo_count" = "%d장";
 
 /* Camera */
 "camera.unavailable_title" = "카메라를 사용할 수 없어요";

--- a/Sahara/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sahara/Resources/zh-Hans.lproj/Localizable.strings
@@ -91,6 +91,12 @@
 "media_selection.photo_permission_message" = "请在设置中允许照片库权限";
 "media_selection.file" = "文件";
 "media_selection.go_to_settings" = "前往设置";
+"media_selection.all_photos" = "所有照片";
+"media_selection.allowed_photos" = "已允许的照片";
+"media_selection.add_photos" = "添加照片";
+"media_selection.limited_banner" = "仅允许访问部分照片";
+"media_selection.allow_all_photos" = "在设置中允许访问所有照片";
+"media_selection.photo_count" = "%d张";
 
 /* Camera */
 "camera.unavailable_title" = "无法使用相机";


### PR DESCRIPTION
Closes #85

## 변경 내용

**추가**
- 앨범 선택 드롭다운 (전체/허용된 사진 + 스마트 앨범 + 사용자 앨범)
- 제한된 접근(limited) 상태에서 안내 배너 표시 및 설정 이동 링크
- 앨범별 사진 필터링 (선택한 앨범의 사진만 그리드에 표시)
- 앨범 목록 셀 (썸네일 + 이름 + 사진 수 + 선택 표시)
- 사진 선택 관련 4개 언어(한/영/일/중) 로컬라이제이션 키 6개

**수정**
- 액션 셀 구성을 권한 상태에 따라 분기 (authorized: 카메라+파일, limited: 카메라+사진 추가+파일)
- 기존 전체 사진 fetch를 앨범 기반 fetch로 전환

**제거**
- macCatalyst 전용이었던 파일 선택 버튼 조건 (iOS에서도 항상 표시)

## 결정 근거

- **앨범 바 + 오버레이 패턴** — 네이티브 사진 앱과 유사한 UX를 위해 드롭다운 방식 채택
- **빈 앨범 자동 필터** — limited 권한에서 허용된 사진이 없는 앨범은 fetch 결과가 0이므로 별도 필터 없이 자연스럽게 제외됨
- **파일 버튼 상시 노출** — macCatalyst 한정이던 것을 iOS에서도 노출하여 접근성 개선