### PR TITLE
Add card-style section grouping to settings screen

### DIFF
--- a/Sahara/Common/Layout/SettingsGroupedLayout.swift
+++ b/Sahara/Common/Layout/SettingsGroupedLayout.swift
@@ -1,0 +1,78 @@
+//
+//  SettingsGroupedLayout.swift
+//  Sahara
+//
+//  Created by 금가경 on 3/27/26.
+//
+
+import UIKit
+
+final class SettingsGroupedLayout: UICollectionViewFlowLayout {
+    private var decorationAttributes: [UICollectionViewLayoutAttributes] = []
+
+    override init() {
+        super.init()
+        minimumLineSpacing = 0
+        minimumInteritemSpacing = 0
+        register(
+            SettingsSectionBackgroundView.self,
+            forDecorationViewOfKind: SettingsSectionBackgroundView.elementKind
+        )
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func prepare() {
+        super.prepare()
+        decorationAttributes.removeAll()
+
+        guard let collectionView = collectionView else { return }
+        let numberOfSections = collectionView.numberOfSections
+
+        for section in 0..<numberOfSections {
+            let numberOfItems = collectionView.numberOfItems(inSection: section)
+            guard numberOfItems > 0 else { continue }
+
+            let firstIndexPath = IndexPath(item: 0, section: section)
+            let lastIndexPath = IndexPath(item: numberOfItems - 1, section: section)
+
+            guard
+                let firstAttributes = layoutAttributesForItem(at: firstIndexPath),
+                let lastAttributes = layoutAttributesForItem(at: lastIndexPath)
+            else { continue }
+
+            let sectionFrame = firstAttributes.frame.union(lastAttributes.frame)
+
+            let attributes = UICollectionViewLayoutAttributes(
+                forDecorationViewOfKind: SettingsSectionBackgroundView.elementKind,
+                with: IndexPath(item: 0, section: section)
+            )
+            attributes.frame = sectionFrame
+            attributes.zIndex = -1
+
+            decorationAttributes.append(attributes)
+        }
+    }
+
+    override func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
+        var allAttributes = super.layoutAttributesForElements(in: rect) ?? []
+        for attributes in decorationAttributes where rect.intersects(attributes.frame) {
+            allAttributes.append(attributes)
+        }
+        return allAttributes
+    }
+
+    override func layoutAttributesForDecorationView(
+        ofKind elementKind: String,
+        at indexPath: IndexPath
+    ) -> UICollectionViewLayoutAttributes? {
+        decorationAttributes.first { $0.indexPath == indexPath }
+    }
+
+    override func shouldInvalidateLayout(forBoundsChange newBounds: CGRect) -> Bool {
+        guard let collectionView = collectionView else { return false }
+        return newBounds.size != collectionView.bounds.size
+    }
+}

--- a/Sahara/Feature/Settings/SettingsMenuCell.swift
+++ b/Sahara/Feature/Settings/SettingsMenuCell.swift
@@ -48,6 +48,12 @@ final class SettingsMenuCell: UICollectionViewCell, IsIdentifiable {
         return toggle
     }()
 
+    private let separatorView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor.black.withAlphaComponent(0.08)
+        return view
+    }()
+
     private var labelStackView: UIStackView = {
         let stack = UIStackView()
         stack.axis = .vertical
@@ -97,6 +103,17 @@ final class SettingsMenuCell: UICollectionViewCell, IsIdentifiable {
             make.trailing.equalToSuperview().inset(20)
             make.centerY.equalToSuperview()
         }
+
+        contentView.addSubview(separatorView)
+        separatorView.snp.makeConstraints { make in
+            make.leading.trailing.equalToSuperview().inset(16)
+            make.bottom.equalToSuperview()
+            make.height.equalTo(0.5)
+        }
+    }
+
+    func setSeparatorHidden(_ hidden: Bool) {
+        separatorView.isHidden = hidden
     }
 
     @objc private func toggleChanged() {

--- a/Sahara/Feature/Settings/SettingsSectionBackgroundView.swift
+++ b/Sahara/Feature/Settings/SettingsSectionBackgroundView.swift
@@ -1,0 +1,29 @@
+//
+//  SettingsSectionBackgroundView.swift
+//  Sahara
+//
+//  Created by 금가경 on 3/27/26.
+//
+
+import UIKit
+
+final class SettingsSectionBackgroundView: UICollectionReusableView {
+    static let elementKind = "SettingsSectionBackground"
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .token(.backgroundGlass)
+        layer.cornerRadius = DesignToken.CornerRadius.card
+        layer.borderWidth = 0.5
+        layer.borderColor = UIColor.black.withAlphaComponent(0.06).cgColor
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func apply(_ layoutAttributes: UICollectionViewLayoutAttributes) {
+        super.apply(layoutAttributes)
+        layer.zPosition = -1
+    }
+}

--- a/Sahara/Feature/Settings/SettingsSectionHeader.swift
+++ b/Sahara/Feature/Settings/SettingsSectionHeader.swift
@@ -12,7 +12,7 @@ final class SettingsSectionHeader: UICollectionReusableView, IsIdentifiable {
     private let titleLabel: UILabel = {
         let label = UILabel()
         label.font = FontSystem.galmuriMono(size: 12)
-        label.textColor = .token(.textPrimary)
+        label.textColor = .token(.textTertiary)
         return label
     }()
 

--- a/Sahara/Feature/Settings/SettingsViewController.swift
+++ b/Sahara/Feature/Settings/SettingsViewController.swift
@@ -21,11 +21,7 @@ final class SettingsViewController: UIViewController {
     private let customNavigationBar = CustomNavigationBar()
 
     private lazy var collectionView: UICollectionView = {
-        let layout = UICollectionViewFlowLayout()
-        layout.minimumLineSpacing = 0
-        layout.minimumInteritemSpacing = 0
-
-        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: SettingsGroupedLayout())
         collectionView.backgroundColor = .clear
         collectionView.register(SettingsMenuCell.self, forCellWithReuseIdentifier: SettingsMenuCell.identifier)
         collectionView.register(
@@ -101,7 +97,7 @@ final class SettingsViewController: UIViewController {
 
     private func bind() {
         let dataSource = RxCollectionViewSectionedReloadDataSource<SettingsSection>(
-            configureCell: { [weak self] _, collectionView, indexPath, item in
+            configureCell: { [weak self] dataSource, collectionView, indexPath, item in
                 guard let cell = collectionView.dequeueReusableCell(
                     withReuseIdentifier: SettingsMenuCell.identifier,
                     for: indexPath
@@ -109,6 +105,9 @@ final class SettingsViewController: UIViewController {
                     return UICollectionViewCell()
                 }
                 cell.configure(with: item)
+
+                let isLastItem = indexPath.item == dataSource[indexPath.section].items.count - 1
+                cell.setSeparatorHidden(isLastItem)
 
                 cell.onToggleChanged = { [weak self] isOn in
                     self?.handleToggleChanged(for: item, isOn: isOn)


### PR DESCRIPTION
Closes #87

## 변경 내용

**추가**
- 설정 화면 섹션별 글래스 배경 카드 (decoration view)
- 섹션별 카드 프레임을 계산하는 커스텀 레이아웃
- 셀 간 구분선 (마지막 항목 제외)

**수정**
- 섹션 헤더 색상을 tertiary로 변경하여 카드와 시각적 계층 분리

## 결정 근거

- **Decoration View 방식** — 셀 자체에 배경을 넣으면 셀 간 경계가 보이므로, UICollectionViewFlowLayout의 decoration view로 섹션 전체를 감싸는 방식 채택