### PR TITLE
Optimize CI build speed with DerivedData cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,6 @@ jobs:
             -skipPackagePluginValidation \
             -skipMacroValidation \
             COMPILER_INDEX_STORE_ENABLE=NO \
-            -enableCodeCoverage NO \
             CODE_SIGNING_ALLOWED=NO
 
       - name: Upload Test Results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,13 +55,27 @@ jobs:
           echo "name=$SCHEME" >> "$GITHUB_OUTPUT"
           echo "Branch target: $BASE → Scheme: $SCHEME"
 
-      - name: Cache SPM
+      - name: Cache DerivedData
         uses: actions/cache@v4
         with:
-          path: ~/Library/Developer/Xcode/DerivedData/**/SourcePackages
-          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          path: ~/Library/Developer/Xcode/DerivedData
+          key: ${{ runner.os }}-dd-${{ steps.scheme.outputs.name }}-${{ hashFiles('**/*.swift', '**/project.pbxproj', '**/Package.resolved') }}
           restore-keys: |
-            ${{ runner.os }}-spm-
+            ${{ runner.os }}-dd-${{ steps.scheme.outputs.name }}-
+            ${{ runner.os }}-dd-
+
+      - name: Boot Simulator
+        run: |
+          DEVICE_ID=$(xcrun simctl list devices available -j | python3 -c "
+          import json, sys
+          devices = json.load(sys.stdin)['devices']
+          for runtime, devs in devices.items():
+            if '18.2' in runtime:
+              for d in devs:
+                if d['name'] == 'iPhone 16':
+                  print(d['udid']); sys.exit()
+          ")
+          xcrun simctl boot "$DEVICE_ID" 2>/dev/null || true &
 
       - name: Build and Test
         run: |
@@ -70,6 +84,9 @@ jobs:
             -configuration Debug \
             -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.2' \
             -skipPackagePluginValidation \
+            -skipMacroValidation \
+            COMPILER_INDEX_STORE_ENABLE=NO \
+            -enableCodeCoverage NO \
             CODE_SIGNING_ALLOWED=NO \
             -resultBundlePath TestResults
 
@@ -80,6 +97,9 @@ jobs:
             -configuration Debug \
             -destination 'platform=iOS Simulator,name=iPad (10th generation),OS=18.2' \
             -skipPackagePluginValidation \
+            -skipMacroValidation \
+            COMPILER_INDEX_STORE_ENABLE=NO \
+            -enableCodeCoverage NO \
             CODE_SIGNING_ALLOWED=NO
 
       - name: Upload Test Results


### PR DESCRIPTION
Closes #99

## 변경 내용

**수정**
- SPM SourcePackages만 캐시하던 것을 DerivedData 전체 캐시로 전환하여 증분 빌드 지원
- iPhone 테스트와 iPad 빌드에 불필요한 작업을 끄는 빌드 플래그 추가
- 빌드 중 시뮬레이터를 백그라운드로 사전 부팅하여 테스트 시작 대기 시간 제거

## 결정 근거

- **DerivedData 전체 캐시** — SourcePackages만 캐시하면 빌드 산출물이 매번 재생성됨. DerivedData를 통째로 캐시해야 증분 빌드가 가능
- **restore-keys 단계적 매칭** — 소스 변경 시에도 이전 DerivedData를 복원하여 변경된 파일만 재컴파일